### PR TITLE
Various markdown format fixes to .md files

### DIFF
--- a/Documentation/AmendmentEndpoint.md
+++ b/Documentation/AmendmentEndpoint.md
@@ -1,11 +1,18 @@
 # Amendment endpoint
+
 ## Coverage
+
 Coverage information for amendment data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more [about amendments](https://www.congress.gov/help/legislative-glossary#glossary_amendment) on Congress.gov.
+
 ## OpenAPI Specification
-View OpenAPI Specification on the amendment API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/amendments/Amendment). 
+
+View OpenAPI Specification on the amendment API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/amendments/Amendment).
+
 ## Elements and Descriptions
+
 ### List Level
-Note that amendment items at the list level can be filtered down by congress and then by amendment type (e.g. https://api.congress.gov/v3/amendment/117/SAMDT?api_key=). 
+
+Note that amendment items at the list level can be filtered down by congress and then by amendment type (e.g. <https://api.congress.gov/v3/amendment/117/SAMDT?api_key>=).
 
 `<api-root>`
 
@@ -14,33 +21,36 @@ The `<api-root>` is only present in the XML format.
 `<amendments>`
 
 Parent container for amendments. An `<amendments>` element may include the following children:
--	`<amendment>`
-    -	Container for an amendment. An `<amendment>` element may include the following children:
-        -	`<number>` (e.g. 2137)
-            -	The assigned amendment number. 
-        -	`<description>`
-            -	The amendment's description.
-            -	Only House amendments will have this element populated.
-        -	`<purpose>` (e.g. In the nature of a substitute.)
-            -	The amendment's purpose.
-            -	House amendments and proposed Senate amendments may have this element populated.
-        -	`<congress>` (e.g. 117)
-            -	The congress during which an amendment was submitted or offered.
-        -	`<type>` (e.g. SAMDT)
-            -	The type of amendment.
-            -	Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
-        - `<latestAction>`
-            -  Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
-                  - `<actionDate>` (e.g. 2021-08-08)
-                      - The date of the latest action taken on the amendment.
-                  -	`<text>` (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.)
-                      -	The text of the latest action taken on the amendment.
-                  -	`<actionTime>`
-                      -	The time of the latest action taken on the amendment. 
-                      -	Certain actions taken by the House contain this element.
-         - `<url>` (e.g. https://api.congress.gov/v3/amendment/117/samdt/2137)
-             - The referrer URL to the amendment item in the API.
+
+- `<amendment>`
+  - Container for an amendment. An `<amendment>` element may include the following children:
+    - `<number>` (e.g. 2137)
+      - The assigned amendment number.
+    - `<description>`
+      - The amendment's description.
+      - Only House amendments will have this element populated.
+    - `<purpose>` (e.g. In the nature of a substitute.)
+      - The amendment's purpose.
+      - House amendments and proposed Senate amendments may have this element populated.
+    - `<congress>` (e.g. 117)
+      - The congress during which an amendment was submitted or offered.
+    - `<type>` (e.g. SAMDT)
+      - The type of amendment.
+      - Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
+    - `<latestAction>`
+      - Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
+        - `<actionDate>` (e.g. 2021-08-08)
+          - The date of the latest action taken on the amendment.
+        - `<text>` (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.)
+          - The text of the latest action taken on the amendment.
+        - `<actionTime>`
+          - The time of the latest action taken on the amendment.
+          - Certain actions taken by the House contain this element.
+    - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/samdt/2137>)
+      - The referrer URL to the amendment item in the API.
+
 ### Item Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -48,133 +58,136 @@ The `<api-root>` is only present in the XML format.
 `<amendment>`
 
 Parent container for an amendment. An `<amendment>` element may include the following children:
-  -	`<number>` (e.g. 2137)
-      -	The assigned amendment number. 
-  -	`<description>`
-    -	The amendment's description.
-    -	Only House amendments will have this element populated.
-  -	`<purpose>` (e.g. In the nature of a substitute.)
-    -	The amendment's purpose.
-    -	House amendments and proposed Senate amendments may have this element populated.
-  -	`<congress>` (e.g. 117)
-    -	The congress during which an amendment was submitted or offered.
-  -	`<type>` (e.g. SAMDT)
-    -	The type of amendment.
-    -	Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
-  -	`<latestAction>`
-    -	Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
-        - `<actionDate>` (e.g. 2021-08-08)
-            - The date of the latest action taken on the amendment.
-        - `<text>` (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.)
-            - The text of the latest action taken on the amendment.
-        - `<actionTime>`
-            - The time of the latest action taken on the amendment. 
-            - Certain actions taken by the House contain this element.
-  -	`<sponsors>`
-    -	Container for the sponsor of the amendment. A `<sponsors>` element may include the following children:
-        -	`<item>`
-            -	Container for a single sponsor of the amendment. An `<item>` element may include the following children:
-                -	`<bioguideId>` (e.g. S001191)
-                      -	The unique identifier for the amendment's sponsor, as assigned in the [Biographical Directory of the United States Congress, 1774-Present](https://bioguide.congress.gov/).
-                      -	View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
-                -	`<fullName>` (e.g. Sen. Sinema, Kyrsten [D-AZ])
-                     - The display name of the amendment's sponsor.
-                -	`<firstName>` (e.g. Kyrsten)
-                     - The first name of the amendment's sponsor.
-                -	`<middleName>` 
-                     - The middle name or initial of the amendment's sponsor.
-                - `<lastName>`(e.g. Sinema)
-                     - The last name of the amendment's sponsor. 
-                -	`<party>` (e.g. D)
-                     - The party code of the amendment's sponsor.
-                -	`<state>` (e.g. AZ)
-                     - A two-letter abbreviation for the state, territory, or district represented by the amendment's sponsor.
-                -	`<url>` (e.g. https://api.congress.gov/v3/member/S001191)
-                     - A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
-                - `<district>` 
-                     - The congressional district that the amendment's sponsor represents.
-                     - Note that this element will be empty for Senate sponsors and will be "0" for states, territories, or districts where there is only one congressional district.
-  -	`<cosponsors>`
-      -	Container for any cosponsors of the amendment. Only Senate amendments may have this element populated.
-      -	A `<cosponsors>` element may include the following children (the below counts are taken from https://api.congress.gov/v3/amendment/117/samdt/3892):
-        -	`<countIncludingWithdrawnCosponsors>` (e.g. 2)
-            -	The total number of cosponsors of the amendment, including any withdrawn cosponsors.
-        -	`<count>` (e.g. 1)
-            -	The current number of cosponsors of the amendment, not including any withdrawn cosponsors. 
-        -	`<url>` (e.g. https://api.congress.gov/v3/amendment/117/samdt/3892/cosponsors)
-            -	A referrer URL to the cosponsors level of the amendment API. Click [here](#cosponsors-level) for more information about the cosponsors level.
-  -	`<proposedDate>` (e.g. 2021-08-01T04:00:00Z)
-      -	The date the amendment was proposed on the floor. 
-      -	This element will only be populated for proposed Senate amendments.
-  -	`<submittedDate>` (e.g. 2021-08-01T04:00:00Z)
-      -	The date the amendment was submitted or offered. 
-  -	`<chamber>` (e.g. Senate)
-      -	The chamber in which the amendment was submitted or offered.
-  -	`<amendedBill>` 
-      -	Container for the bill amended by the amendment. An `<amendedBill>` element may include the following children:
-          -	`<congress>` (e.g. 117) 
-             -	The congress during which the bill or resolution was introduced or submitted.
-         -	`<type>` (e.g. HR)
-              -	The type of bill or resolution. 
-              -	Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
-         -	`<originChamber>` (e.g. House)
-              -	The chamber of origin where a bill or resolution was introduced or submitted.
-              -	Possible values are "House" and "Senate".
-         - `<originChamberCode>` (e.g. H)
-              -	The code for the chamber of origin where the bill or resolution was introduced or submitted.
-              -	Possible values are "H" and "S".
-        -	`<number>` (e.g. 3684)
-             - The assigned bill or resolution number.
-        -	`<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3684)
-            -	A referrer URL to the bill or resolution item in the API. Documentation for the bill endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
-        -	`<title>` (e.g. Infrastructure Investment and Jobs Act)
-            -	The display title for the bill or resolution on Congress.gov.
--	`<amendedAmendment>` 
-    -	Container for the amendment amended by the amendment. An `<amendedAmendment>` element may include the following children (the below amendment data is taken from https://api.congress.gov/v3/amendment/117/samdt/2564) :
-        -	`<number>` (e.g. 2137)
-            -	The assigned amendment number.
-        - `<description>`
-            - The amendment's description.
-            - Only House amendments will have this element populated.
-        -	`<purpose>` (e.g. In the nature of a substitute.)
-            - The amendment's purpose.
-            - House amendments and proposed Senate amendments may have this element populated.
-        -	`<congress>` (e.g. 117)
-            - The congress during which an amendment was submitted or offered.
-        -	`<type>` (e.g. SAMDT)
-            - The type of amendment.
-            - Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
-        -	`<url>` (e.g. https://api.congress.gov/v3/amendment/117/samdt/2137)
-            - A referrer URL to the amendment item in the API.
-  -	`<amendmentsToAmendment>`
-    -	Container for amendments to the amendment. An `<amendmentsToAmendment>` element may contain the following children:
-        -	`<count>` (e.g. 507)
-            -	The number of amendments to the amendment. 
-        -	`<url>` (e.g. https://api.congress.gov/v3/amendment/117/samdt/2137/amendments)
-            -	A referrer URL to the amendment to amendments level of the amendment API. Click [here](#amendments-to-amendment-level) for more information about the amendments to amendments level.
-  -	`<notes>`
-      -	Container for notes attached to the amendment on Congress.gov. The note may contain supplemental information about the amendment that users may find helpful. Read more [about notes](https://www.congress.gov/help/legislative-glossary#glossary_notes) on Congress.gov.
-      -	A  `<notes>` element may include the following children:
-        -	`<item>`
-            -	Container for a note. An `<item>` element may include the following children:
-                -	`<text>` (e.g. `<![CDATA[ The Senate agreed to the amendment on 12/5/2016, then vitiated its adoption on 12/5/2016, then agreed to the amendment on 12/10/2016. ]]>`)
-                    -	The text of the note on Congress.gov (from https://api.congress.gov/v3/amendment/114/samdt/5129).
-                    - Note that the text is encased in CDATA.
-  -	`<amendedTreaty>`
-      -	Container for the treaty amended by the amendment. An `<amendedTreaty>` element may contain the following children (the below treaty data is taken from https://api.congress.gov/v3/amendment/117/samdt/2137):
-        -	`<congress>` (e.g. 116)
-            -	The congress during which a treaty was submitted. 
-        -	`<treatyNumber>` (e.g. 1)
-            -	The assigned treaty number.
-        -	`<url>` (e.g. https://api.congress.gov/v3/treaty/116/1)
-            -	A referrer URL to the treaty item in the API. Documentation for the treaty endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/TreatyEndpoint.md).
-  -	`<actions>`
-      - Container for actions on the amendment. An `<actions>` element may include the following children:
-          - `<count>` (e.g. 19)
-              - The number of actions on the amendment. A `<count>` element may include actions from the House, Senate, and Library of Congress.
-          - `<url>` (e.g. https://api.congress.gov/v3/amendment/117/samdt/2137/actions)
-              - A referrer URL to the actions level of the amendment API. Click [here](#actions-level) for more information about the actions level.
+
+- `<number>` (e.g. 2137)
+  - The assigned amendment number.
+- `<description>`
+  - The amendment's description.
+  - Only House amendments will have this element populated.
+- `<purpose>` (e.g. In the nature of a substitute.)
+  - The amendment's purpose.
+  - House amendments and proposed Senate amendments may have this element populated.
+- `<congress>` (e.g. 117)
+  - The congress during which an amendment was submitted or offered.
+- `<type>` (e.g. SAMDT)
+  - The type of amendment.
+  - Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
+- `<latestAction>`
+  - Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
+    - `<actionDate>` (e.g. 2021-08-08)
+      - The date of the latest action taken on the amendment.
+    - `<text>` (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.)
+      - The text of the latest action taken on the amendment.
+    - `<actionTime>`
+      - The time of the latest action taken on the amendment.
+      - Certain actions taken by the House contain this element.
+- `<sponsors>`
+  - Container for the sponsor of the amendment. A `<sponsors>` element may include the following children:
+    - `<item>`
+      - Container for a single sponsor of the amendment. An `<item>` element may include the following children:
+        - `<bioguideId>` (e.g. S001191)
+          - The unique identifier for the amendment's sponsor, as assigned in the [Biographical Directory of the United States Congress, 1774-Present](https://bioguide.congress.gov/).
+          - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
+        - `<fullName>` (e.g. Sen. Sinema, Kyrsten [D-AZ])
+          - The display name of the amendment's sponsor.
+        - `<firstName>` (e.g. Kyrsten)
+          - The first name of the amendment's sponsor.
+        - `<middleName>`
+          - The middle name or initial of the amendment's sponsor.
+        - `<lastName>`(e.g. Sinema)
+          - The last name of the amendment's sponsor.
+        - `<party>` (e.g. D)
+          - The party code of the amendment's sponsor.
+        - `<state>` (e.g. AZ)
+          - A two-letter abbreviation for the state, territory, or district represented by the amendment's sponsor.
+        - `<url>` (e.g. <https://api.congress.gov/v3/member/S001191>)
+          - A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
+        - `<district>`
+          - The congressional district that the amendment's sponsor represents.
+          - Note that this element will be empty for Senate sponsors and will be "0" for states, territories, or districts where there is only one congressional district.
+- `<cosponsors>`
+  - Container for any cosponsors of the amendment. Only Senate amendments may have this element populated.
+  - A `<cosponsors>` element may include the following children (the below counts are taken from <https://api.congress.gov/v3/amendment/117/samdt/3892>):
+    - `<countIncludingWithdrawnCosponsors>` (e.g. 2)
+      - The total number of cosponsors of the amendment, including any withdrawn cosponsors.
+    - `<count>` (e.g. 1)
+      - The current number of cosponsors of the amendment, not including any withdrawn cosponsors.
+    - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/samdt/3892/cosponsors>)
+      - A referrer URL to the cosponsors level of the amendment API. Click [here](#cosponsors-level) for more information about the cosponsors level.
+- `<proposedDate>` (e.g. 2021-08-01T04:00:00Z)
+  - The date the amendment was proposed on the floor.
+  - This element will only be populated for proposed Senate amendments.
+- `<submittedDate>` (e.g. 2021-08-01T04:00:00Z)
+  - The date the amendment was submitted or offered.
+- `<chamber>` (e.g. Senate)
+  - The chamber in which the amendment was submitted or offered.
+- `<amendedBill>`
+  - Container for the bill amended by the amendment. An `<amendedBill>` element may include the following children:
+    - `<congress>` (e.g. 117)
+      - The congress during which the bill or resolution was introduced or submitted.
+    - `<type>` (e.g. HR)
+      - The type of bill or resolution.
+      - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
+    - `<originChamber>` (e.g. House)
+      - The chamber of origin where a bill or resolution was introduced or submitted.
+      - Possible values are "House" and "Senate".
+    - `<originChamberCode>` (e.g. H)
+      - The code for the chamber of origin where the bill or resolution was introduced or submitted.
+      - Possible values are "H" and "S".
+    - `<number>` (e.g. 3684)
+      - The assigned bill or resolution number.
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3684>)
+      - A referrer URL to the bill or resolution item in the API. Documentation for the bill endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
+    - `<title>` (e.g. Infrastructure Investment and Jobs Act)
+      - The display title for the bill or resolution on Congress.gov.
+- `<amendedAmendment>`
+  - Container for the amendment amended by the amendment. An `<amendedAmendment>` element may include the following children (the below amendment data is taken from <https://api.congress.gov/v3/amendment/117/samdt/2564>) :
+    - `<number>` (e.g. 2137)
+      - The assigned amendment number.
+    - `<description>`
+      - The amendment's description.
+      - Only House amendments will have this element populated.
+    - `<purpose>` (e.g. In the nature of a substitute.)
+      - The amendment's purpose.
+      - House amendments and proposed Senate amendments may have this element populated.
+    - `<congress>` (e.g. 117)
+      - The congress during which an amendment was submitted or offered.
+    - `<type>` (e.g. SAMDT)
+      - The type of amendment.
+      - Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
+    - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/samdt/2137>)
+      - A referrer URL to the amendment item in the API.
+- `<amendmentsToAmendment>`
+  - Container for amendments to the amendment. An `<amendmentsToAmendment>` element may contain the following children:
+    - `<count>` (e.g. 507)
+      - The number of amendments to the amendment.
+    - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/samdt/2137/amendments>)
+      - A referrer URL to the amendment to amendments level of the amendment API. Click [here](#amendments-to-amendment-level) for more information about the amendments to amendments level.
+- `<notes>`
+  - Container for notes attached to the amendment on Congress.gov. The note may contain supplemental information about the amendment that users may find helpful. Read more [about notes](https://www.congress.gov/help/legislative-glossary#glossary_notes) on Congress.gov.
+  - A  `<notes>` element may include the following children:
+    - `<item>`
+      - Container for a note. An `<item>` element may include the following children:
+        - `<text>` (e.g. `<![CDATA[ The Senate agreed to the amendment on 12/5/2016, then vitiated its adoption on 12/5/2016, then agreed to the amendment on 12/10/2016. ]]>`)
+          - The text of the note on Congress.gov (from <https://api.congress.gov/v3/amendment/114/samdt/5129>).
+          - Note that the text is encased in CDATA.
+- `<amendedTreaty>`
+  - Container for the treaty amended by the amendment. An `<amendedTreaty>` element may contain the following children (the below treaty data is taken from <https://api.congress.gov/v3/amendment/117/samdt/2137>):
+    - `<congress>` (e.g. 116)
+      - The congress during which a treaty was submitted.
+    - `<treatyNumber>` (e.g. 1)
+      - The assigned treaty number.
+    - `<url>` (e.g. <https://api.congress.gov/v3/treaty/116/1>)
+      - A referrer URL to the treaty item in the API. Documentation for the treaty endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/TreatyEndpoint.md).
+- `<actions>`
+  - Container for actions on the amendment. An `<actions>` element may include the following children:
+    - `<count>` (e.g. 19)
+      - The number of actions on the amendment. A `<count>` element may include actions from the House, Senate, and Library of Congress.
+    - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/samdt/2137/actions>)
+      - A referrer URL to the actions level of the amendment API. Click [here](#actions-level) for more information about the actions level.
+
 ## Actions Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -182,62 +195,65 @@ The `<api-root>` is only present in the XML format.
 `<actions>`
 
 Parent container for all actions taken on an amendment. Actions may come from the House, Senate, or Library of Congress. An `<actions>` element may include the following children:
--	`<item>` 
-    -	Container for an action taken on an amendment. An `<item>` element is repeatable and may include the following children:
-        -	`<actionDate>` (e.g. 2021-08-08)
-            -	The date of the action taken on an amendment.
-        -	`<actionTime>`
-            -	The time of the action taken on an amendment. 
-            -	Certain actions taken by the House contain this element.
-        -	`<text>` (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.)
-            -	The text of the action taken on an amendment.
-        -	`<type>` (e.g. Floor)
-            -	A short name representing legislative process stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent House or Senate legislative process activities.
-            -	Possible values are "Committee", "Floor", "IntroReferral", "ResolvingDifferences", and "NotUsed".
-        -	`<actionCode>`
-            -	An action code associated with the action taken on an amendment. 
-            -	The `<actionCode>` element will be present only for actions where the `<sourceSystem>` is 2 (House) or 9 (Library of Congress).
-                -	[Action Codes](https://www.congress.gov/help/field-values/action-codes) is an authoritative list of values where the `<sourceSystem>` is 9 (Library of Congress).
-                -	An authoritative list of values where the `<sourceSystem>` is 2 (House) does not exist.
-            -	Various code sets are used by multiple systems in the House, Senate, and Library of Congress by legislative clerks and data editors for functions independent of this data set. As new codes and systems were developed, there was no coordinated effort to retroactively apply new codes to old records. Many codes are concatenated with other codes or elements or utilize free text. Codes in one set may be redundant with a different code in another code set. Additionally, some codes may have been used and re-used over the years for different purposes further complicating the ability to create an authoritative list. View the original code set of [U.S. Congress legislative status steps](http://www.loc.gov/pictures/resource/ppmsca.33996/).
-         - `<sourceSystem>`
-            -	Container for the source system where the action was entered. A `<sourceSystem>` element may include the following children:
-                - `<code>` (e.g. 0)
-                    -	A code for the source system that entered the action.
-                    -	Possible values are "0", "1", "2", or "9".
-                    -	"0" is for Senate, "1" and "2" are for House, and "9" is Library of Congress.
-                - `<name>` (e.g. Senate)
-                    - The name of the source system that entered the action.
-                    - Possible values are "Senate", "House committee actions", "House floor actions", and "Library of Congress".
-          - `<committees>`
-            -	Container for committees associated with the action. A `<committees>` element may include the following children:
-                -	`<item>`
-                    -	Container for a committee associated with the action. An `<item>` element is repeatable and may include the following children:
-                        -	`<url>`
-                            -	A referrer URL to the committee or subcommittee in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
-                        -	`<systemCode>`
-                            -	Unique ID value for the committee or subcommittee.
-                        -	`<name>`
-                            -	The name of the committee or subcommittee associated with the action. 
-          -	`<recordedVotes>`
-              -	Container for recorded (roll call) votes associated with the action. Read more [about roll call votes]( https://www.congress.gov/help/legislative-glossary#glossary_rollcallvote) on Congress.gov. More information can also be found at the [Roll Call Votes by the U.S. Congress](https://www.congress.gov/roll-call-votes) and [Votes in the House and Senate](https://www.congress.gov/help/votes-in-the-house-and-senate) pages on Congress.gov. 
-                  -	A `<recordedVotes>` element may include the following children:
-                      -	`<recordedVote>`
-                          -	Container for a recorded (roll call) vote associated with the action. A `<recordedVote>` element may include the following children:
-                              - `<rollNumber>` (e.g. 312)
-                                  - The recorded (roll call) vote number. 
-                              - `<url>` (e.g. https://www.senate.gov/legislative/LIS/roll_call_votes/vote1171/vote_117_1_00312.xml)
-                                  - The url to the recorded (roll call) vote on [Senate.gov](https://www.senate.gov/legislative/votes_new.htm) or [Clerk.House.gov](https://clerk.house.gov/Votes).
-                              - `<chamber>` (e.g. Senate)
-                                  - The chamber where the recorded (roll call) vote took place.
-                                  -	Possible values are "House" and "Senate".
-                              - `<congress>` (e.g. 117)
-                                  -	The congress during which the recorded (roll call) vote took place.
-                              - `<date>` (e.g. 2021-08-09T00:45:48Z)
-                                  - The date of the recorded (roll call) vote.
-                              - `<sessionNumber>` (e.g. 1)
-                                  - The session of congress during which the recorded (roll call) vote took place. 
+
+- `<item>`
+  - Container for an action taken on an amendment. An `<item>` element is repeatable and may include the following children:
+    - `<actionDate>` (e.g. 2021-08-08)
+      - The date of the action taken on an amendment.
+    - `<actionTime>`
+      - The time of the action taken on an amendment.
+      - Certain actions taken by the House contain this element.
+    - `<text>` (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.)
+      - The text of the action taken on an amendment.
+    - `<type>` (e.g. Floor)
+      - A short name representing legislative process stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent House or Senate legislative process activities.
+      - Possible values are "Committee", "Floor", "IntroReferral", "ResolvingDifferences", and "NotUsed".
+    - `<actionCode>`
+      - An action code associated with the action taken on an amendment.
+      - The `<actionCode>` element will be present only for actions where the `<sourceSystem>` is 2 (House) or 9 (Library of Congress).
+        - [Action Codes](https://www.congress.gov/help/field-values/action-codes) is an authoritative list of values where the `<sourceSystem>` is 9 (Library of Congress).
+        - An authoritative list of values where the `<sourceSystem>` is 2 (House) does not exist.
+      - Various code sets are used by multiple systems in the House, Senate, and Library of Congress by legislative clerks and data editors for functions independent of this data set. As new codes and systems were developed, there was no coordinated effort to retroactively apply new codes to old records. Many codes are concatenated with other codes or elements or utilize free text. Codes in one set may be redundant with a different code in another code set. Additionally, some codes may have been used and re-used over the years for different purposes further complicating the ability to create an authoritative list. View the original code set of [U.S. Congress legislative status steps](http://www.loc.gov/pictures/resource/ppmsca.33996/).
+    - `<sourceSystem>`
+      - Container for the source system where the action was entered. A `<sourceSystem>` element may include the following children:
+        - `<code>` (e.g. 0)
+          - A code for the source system that entered the action.
+          - Possible values are "0", "1", "2", or "9".
+          - "0" is for Senate, "1" and "2" are for House, and "9" is Library of Congress.
+        - `<name>` (e.g. Senate)
+          - The name of the source system that entered the action.
+          - Possible values are "Senate", "House committee actions", "House floor actions", and "Library of Congress".
+    - `<committees>`
+      - Container for committees associated with the action. A `<committees>` element may include the following children:
+        - `<item>`
+          - Container for a committee associated with the action. An `<item>` element is repeatable and may include the following children:
+            - `<url>`
+              - A referrer URL to the committee or subcommittee in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
+            - `<systemCode>`
+              - Unique ID value for the committee or subcommittee.
+            - `<name>`
+              - The name of the committee or subcommittee associated with the action.
+    - `<recordedVotes>`
+      - Container for recorded (roll call) votes associated with the action. Read more [about roll call votes]( https://www.congress.gov/help/legislative-glossary#glossary_rollcallvote) on Congress.gov. More information can also be found at the [Roll Call Votes by the U.S. Congress](https://www.congress.gov/roll-call-votes) and [Votes in the House and Senate](https://www.congress.gov/help/votes-in-the-house-and-senate) pages on Congress.gov.
+        - A `<recordedVotes>` element may include the following children:
+          - `<recordedVote>`
+            - Container for a recorded (roll call) vote associated with the action. A `<recordedVote>` element may include the following children:
+              - `<rollNumber>` (e.g. 312)
+                - The recorded (roll call) vote number.
+              - `<url>` (e.g. <https://www.senate.gov/legislative/LIS/roll_call_votes/vote1171/vote_117_1_00312.xml>)
+                - The url to the recorded (roll call) vote on [Senate.gov](https://www.senate.gov/legislative/votes_new.htm) or [Clerk.House.gov](https://clerk.house.gov/Votes).
+              - `<chamber>` (e.g. Senate)
+                - The chamber where the recorded (roll call) vote took place.
+                - Possible values are "House" and "Senate".
+              - `<congress>` (e.g. 117)
+                - The congress during which the recorded (roll call) vote took place.
+              - `<date>` (e.g. 2021-08-09T00:45:48Z)
+                - The date of the recorded (roll call) vote.
+              - `<sessionNumber>` (e.g. 1)
+                - The session of congress during which the recorded (roll call) vote took place.
+
 ## Amendments To Amendment Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -245,33 +261,36 @@ The `<api-root>` is only present in the XML format.
 `<amendments>`
 
 Parent container for all amendments to the amendment. An `<amendments>` element may include the following children:
--	`<amendment>`
-    -	Container for an amendment to the amendment. An `<amendment>` element is repeatable and may include the following children:
-        -	`<number>` (e.g. 2300)
-            -	The assigned amendment number. 
-        -	`<description>`
-            -	The amendment's description.
-            -	Only House amendments will have this element populated.
-        -	`<purpose>` (e.g. To designate additional high priority corridors on the National Highway system.)
-            -	The amendment's purpose.
-            -	House amendments and proposed Senate amendments may have this element populated.
-        -	`<congress>` (e.g. 117)
-            -	The congress during which an amendment was submitted or offered.
-        -	`<type>` (e.g. SAMDT)
-            -	The type of amendment.
-            -	Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
-        -	`<latestAction>`
-            -	Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
-                -	`<actionDate>` (e.g. 2021-08-03)
-                    -	The date of the latest action taken on the amendment.
-                -	`<actionTime>`
-                    -	The time of the latest action taken on the amendment.
-                    -	Certain actions taken by the House contain this element.
-                -	`<text>` (e.g. Amendment SA 2300 agreed to in Senate by Voice Vote.)
-                    - The text of the latest action taken on the amendment.
-                -	`<url>` (e.g. https://api.congress.gov/v3/amendment/117/samdt/2300)
-                    -	A referrer URL to the amendment item in the API.
+
+- `<amendment>`
+  - Container for an amendment to the amendment. An `<amendment>` element is repeatable and may include the following children:
+    - `<number>` (e.g. 2300)
+      - The assigned amendment number.
+    - `<description>`
+      - The amendment's description.
+      - Only House amendments will have this element populated.
+    - `<purpose>` (e.g. To designate additional high priority corridors on the National Highway system.)
+      - The amendment's purpose.
+      - House amendments and proposed Senate amendments may have this element populated.
+    - `<congress>` (e.g. 117)
+      - The congress during which an amendment was submitted or offered.
+    - `<type>` (e.g. SAMDT)
+      - The type of amendment.
+      - Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
+    - `<latestAction>`
+      - Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
+        - `<actionDate>` (e.g. 2021-08-03)
+          - The date of the latest action taken on the amendment.
+        - `<actionTime>`
+          - The time of the latest action taken on the amendment.
+          - Certain actions taken by the House contain this element.
+        - `<text>` (e.g. Amendment SA 2300 agreed to in Senate by Voice Vote.)
+          - The text of the latest action taken on the amendment.
+        - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/samdt/2300>)
+          - A referrer URL to the amendment item in the API.
+
 ## Cosponsors Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -279,35 +298,36 @@ The `<api-root>` is only present in the XML format.
 `<cosponsors>`
 
 Parent container for cosponsors of an amendment. Read more [about cosponsors](https://www.congress.gov/help/legislative-glossary#glossary_cosponsor) on Congress.gov. Only Senate amendments will have this deeper level. A `<cosponsors>` element may include the following children:
--	`<item>`
-    -	Container for a cosponsor of an amendment. An `<item>` element is repeatable and may include the following children:
-        -	`<bioguideId>` (e.g. P000449)
-            -	The unique identifier for the amendment cosponsor, as assigned in the [Biographical Directory of the United States Congress, 1774-Present](http://bioguide.congress.gov/).
-            -	View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
-        -	`<fullName>` (e.g. Sen. Portman, Rob [R-OH])
-            -	The display name for the amendment cosponsor.
-        -	`<firstName>` (e.g. Rob)
-            -	The first name of the amendment cosponsor.
-        -	`<middleName>`
-            - The middle name or initial of the amendment cosponsor. 
-        -	`<lastName>` (e.g. Portman)
-            -	The last name of the amendment cosponsor.
-        -	`<party>` (e.g. R)
-            -	The party code of the amendment cosponsor.
-            -	Possible values are "D", "R", "I", "ID", and "L".
-        -	`<state>` (e.g. OH)
-            -	A two-letter abbreviation for the state, territory, or district represented by the amendment cosponsor.
-        -	`<url>` (e.g. https://api.congress.gov/v3/member/P000449)
-            -	A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
-        -	`<sponsorshipDate>` (e.g. 2021-08-01)
-            -	The date the member became a cosponsor of the amendment.
-        -	`<isOriginalCosponsor>` (e.g. True)
-             - A designation that the member is an original or additional cosponsor of the amendment. If the member cosponsored the amendment on the date of its submission, then this value will be "True". If the member cosponsored the amendment after its date of submission, then this value will be "False".
-             - Possible values are "True" or "False".
-        -	`<sponsorshipWithdrawnDate>`
-             - The date the cosponsor withdrew their cosponsorship of amendment.
-  -	`<pagination>` (from https://api.congress.gov/v3/amendment/117/samdt/3892)
-      -	`<count>` (e.g. 1)
-          -	The current count of cosponsors of the amendment, not including any withdrawn cosponsors.
-      -	`<countIncludingWithdrawnCosponsors>` (e.g. 2)
-          -	The total number of cosponsors of the amendment, including any withdrawn cosponsors.
+
+- `<item>`
+  - Container for a cosponsor of an amendment. An `<item>` element is repeatable and may include the following children:
+    - `<bioguideId>` (e.g. P000449)
+      - The unique identifier for the amendment cosponsor, as assigned in the [Biographical Directory of the United States Congress, 1774-Present](http://bioguide.congress.gov/).
+      - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
+    - `<fullName>` (e.g. Sen. Portman, Rob [R-OH])
+      - The display name for the amendment cosponsor.
+    - `<firstName>` (e.g. Rob)
+      - The first name of the amendment cosponsor.
+    - `<middleName>`
+      - The middle name or initial of the amendment cosponsor.
+    - `<lastName>` (e.g. Portman)
+      - The last name of the amendment cosponsor.
+    - `<party>` (e.g. R)
+      - The party code of the amendment cosponsor.
+      - Possible values are "D", "R", "I", "ID", and "L".
+    - `<state>` (e.g. OH)
+      - A two-letter abbreviation for the state, territory, or district represented by the amendment cosponsor.
+    - `<url>` (e.g. <https://api.congress.gov/v3/member/P000449>)
+      - A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
+    - `<sponsorshipDate>` (e.g. 2021-08-01)
+      - The date the member became a cosponsor of the amendment.
+    - `<isOriginalCosponsor>` (e.g. True)
+      - A designation that the member is an original or additional cosponsor of the amendment. If the member cosponsored the amendment on the date of its submission, then this value will be "True". If the member cosponsored the amendment after its date of submission, then this value will be "False".
+      - Possible values are "True" or "False".
+    - `<sponsorshipWithdrawnDate>`
+      - The date the cosponsor withdrew their cosponsorship of amendment.
+- `<pagination>` (from <https://api.congress.gov/v3/amendment/117/samdt/3892>)
+  - `<count>` (e.g. 1)
+    - The current count of cosponsors of the amendment, not including any withdrawn cosponsors.
+  - `<countIncludingWithdrawnCosponsors>` (e.g. 2)
+    - The total number of cosponsors of the amendment, including any withdrawn cosponsors.

--- a/Documentation/BillEndpoint.md
+++ b/Documentation/BillEndpoint.md
@@ -1,12 +1,20 @@
 # Bill endpoint
+
 ## Coverage
+
 Coverage information for bill data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Projects to add more historical legislative data to Congress.gov are underway. Read more about bill data at [About Legislation of the U.S. Congress](https://www.congress.gov/help/legislation) on Congress.gov.
+
 ## OpenAPI Specification
-View OpenAPI Specification on the bill API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/bill/bill_list_all). 
+
+View OpenAPI Specification on the bill API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/bill/bill_list_all).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
-Note that bill items at the list level can be filtered down by congress (e.g. 117) and by bill type (e.g. HR) - https://api.congress.gov/v3/bill/117/hr?api_key=.
+
+Note that bill items at the list level can be filtered down by congress (e.g. 117) and by bill type (e.g. HR) - <https://api.congress.gov/v3/bill/117/hr?api_key>=.
 
 `<api-root>`
 
@@ -15,23 +23,24 @@ The `<api-root>` is only present in the XML format.
 `<bills>`
 
 Parent container for bills and resolutions. A `<bills>` element may include the following children:
+
 - `<bill>`
   - Container for a bill or resolution. A `<bill>` element may include the following children:
     - `<congress>` (e.g. 117)
       - The congress during which a bill or resolution was introduced or submitted.
       - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
     - `<type>` (e.g. HR)
-      - The type of bill or resolution. 
+      - The type of bill or resolution.
       - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
     - `<originChamber>` (e.g. House)
       - The chamber of origin where a bill or resolution was introduced or submitted.
       - Possible values are "House" and "Senate".
     - `<originChamberCode>` (e.g. H)
-      - The code for the chamber of origin where the bill or resolution was introduced or submitted. 
+      - The code for the chamber of origin where the bill or resolution was introduced or submitted.
       - Possible values are "H" and "S".
     - `<number>` (e.g. 3076)
       - The assigned bill or resolution number.
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076)
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076>)
       - A referrer URL to the bill or resolution item in the API.
     - `<title>` (e.g. Postal Service Reform Act of 2022)
       - The display title for the bill or resolution on Congress.gov.
@@ -45,7 +54,9 @@ Parent container for bills and resolutions. A `<bills>` element may include the 
           - The time of the latest action taken on the bill or resolution. Certain actions taken by the House contain this element.
     - `<updateDate>` (e.g. 2022-05-05)
       - The date of update on Congress.gov. This update date does not include updates to bill text.
+
 ### Item Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -53,6 +64,7 @@ The `<api-root>` is only present in the XML format.
 `<bill>`
 
 Parent container for a bill or resolution. A `<bill>` element may include the following children:
+
 - `<number>` (e.g. 3076)
   - The assigned bill or resolution number.
 - `<updateDate>` (e.g. 2022-05-05)
@@ -63,7 +75,7 @@ Parent container for a bill or resolution. A `<bill>` element may include the fo
   - The chamber of origin where a bill or resolution was introduced or submitted.
   - Possible values are "House" and "Senate".
 - `<type>` (e.g. HR)
-  - The type of bill or resolution. 
+  - The type of bill or resolution.
   - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
 - `<introducedDate>`(e.g. 2021-05-11)
   - The date the bill or resolution was submitted or introduced.
@@ -73,69 +85,69 @@ Parent container for a bill or resolution. A `<bill>` element may include the fo
 - `<constitutionalAuthorityStatementText>` (e.g. `<![CDATA[ <pre>[Congressional Record Volume 167, Number 81 (Tuesday, May 11, 2021)][House]From the Congressional Record Online through the Government Publishing Office [<a href="https://www.gpo.gov">www.gpo.gov</a>]By Mrs. CAROLYN B. MALONEY of New York:H.R. 3076.Congress has the power to enact this legislation pursuantto the following:Article I, Section I, Clause 18 (Necessary and ProperClause)[Page H2195]</pre> ]]>`)
   - Text extracted from the Congressional Record to accompany House Bills (HR) and House Joint Resolutions (HJRES) that cites the power granted to Congress by the Constitution to enact the proposed law, as required by Clause 7 of House Rule XII. Read more about constitutional authority statements on the [House Rules Committee website](https://rules.house.gov/rules-and-resources/constitutional-authority-statements).
   - Note that the text is encased in CDATA.
-- `<committees>` 
-  - Container for committees or subcommittees with activity associated with the bill or resolution. Read more [About Committees and Committee Materials](https://www.congress.gov/help/committee-materials) on Congress.gov. 
+- `<committees>`
+  - Container for committees or subcommittees with activity associated with the bill or resolution. Read more [About Committees and Committee Materials](https://www.congress.gov/help/committee-materials) on Congress.gov.
   - A `<committees>` element may include the following children:
     - `<count>` (e.g. 3)
       - The number of committees with activity associated with the bill or resolution.
-    -  `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/committees)
-       - A referrer URL to the committees level of the bill API. Click [here](#committees-level) for more information about the committees level. 
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/committees>)
+      - A referrer URL to the committees level of the bill API. Click [here](#committees-level) for more information about the committees level.
 - `<committeeReports>`
-  - Container for committee reports associated with the bill or resolution. Read more [About Committee Reports of the U.S. Congress](https://www.congress.gov/help/committee-reports) on Congress.gov. 
+  - Container for committee reports associated with the bill or resolution. Read more [About Committee Reports of the U.S. Congress](https://www.congress.gov/help/committee-reports) on Congress.gov.
   - A `<committeeReports>` element may include the following children:
     - `<committeeReport>`
       - Container for an individual committee report related to the bill or resolution. A `<committeeReport>` element may include the following children:
         - `<citation>` (e.g. H. Rept. 117-89,Part 1)
           - The committee report citation.
-        - `<url>` (e.g. https://api.congress.gov/v3/committee-report/117/HRPT/89)
+        - `<url>` (e.g. <https://api.congress.gov/v3/committee-report/117/HRPT/89>)
           - A referrer URL to the committee report item in the API. Documentation for the committee report endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeReportEndpoint.md).
 - `<relatedBills>`
-  - Container for related bills to the bill or resolution, as assigned by CRS, the House, and the Senate. Read [About Related Bills](https://www.congress.gov/help/related-bills) on Congress.gov. 
+  - Container for related bills to the bill or resolution, as assigned by CRS, the House, and the Senate. Read [About Related Bills](https://www.congress.gov/help/related-bills) on Congress.gov.
   - A `<relatedBills>` element may include the following children:
     - `<count>` (e.g. 2)
       - The number of related bills assigned to the bill or resolution.
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/relatedbills)
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/relatedbills>)
       - A referrer URL to the related bills level of the bill API. Click [here](#related-bills-level) for more information about the related bills level.
-- `<actions>` 
+- `<actions>`
   - Container for actions on the bill or resolution. An `<actions>` element may include the following children:
     - `<count>` (e.g. 30)
       - The number of actions on the bill or resolution. The `<count>` includes actions from the House, Senate, and Library of Congress.
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/actions)
-      - A referrer URL to the actions level of the bill API. Click [here](#actions-level) for more information about the actions level. 
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/actions>)
+      - A referrer URL to the actions level of the bill API. Click [here](#actions-level) for more information about the actions level.
 - `<sponsors>`
   - Container for the sponsor of the bill or resolution. A `<sponsors>` element may include the following children:
     - `<item>`
       - Container for a single sponsor of the bill or resolution. The `<item>` element may include the following children:
         - `<bioguideId>` (e.g. M000087)
           - The unique identifier for the bill or resolution sponsor, as assigned in the [Biographical Directory of the United States Congress, 1774-Present](http://bioguide.congress.gov/).
-          - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov. 
+          - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
         - `<fullName>` (e.g. Rep. Maloney, Carolyn B. [D-NY-12])
-          - The display name of the bill or resolution sponsor. 
+          - The display name of the bill or resolution sponsor.
         - `<firstName>` (e.g. Carolyn)
           - The first name of the bill or resolution sponsor.
         - `<middleName>` (e.g. B.)
           - The middle name or initial of the bill or resolution sponsor.
         - `<lastName>` (e.g. Maloney)
-          - The last name of the bill or resolution sponsor. 
+          - The last name of the bill or resolution sponsor.
         - `<party>` (e.g. D)
           - The party code of the bill or resolution sponsor.
         - `<state>` (e.g. NY)
           - A two-letter abbreviation for the state, territory, or district represented by the bill or resolution sponsor.
-        - `<url>` (e.g. https://api.congress.gov/v3/member/M000087)
+        - `<url>` (e.g. <https://api.congress.gov/v3/member/M000087>)
           - A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
         - `<district>` (e.g. 12)
           - The congressional district that the bill or resolution sponsor represents.
           - Note that this element will be "0" for states, territories, or districts where there is only one congressional district.
-         - `<isByRequest>` (e.g. N)
-           - Flag indicating if the bill or resolution was introduced at the request of the President or another entity.
-           - Possible values are "Y" or "N".
+        - `<isByRequest>` (e.g. N)
+          - Flag indicating if the bill or resolution was introduced at the request of the President or another entity.
+          - Possible values are "Y" or "N".
 - `<cosponsors>`
-  - Container for any cosponsors of the bill or resolution. A `<cosponsors>` element may include the following children (the below counts are taken from https://api.congress.gov/v3/bill/117/s/3580/cosponsors):
+  - Container for any cosponsors of the bill or resolution. A `<cosponsors>` element may include the following children (the below counts are taken from <https://api.congress.gov/v3/bill/117/s/3580/cosponsors>):
     - `<countIncludingWithdrawnCosponsors>` (e.g. 31)
       - The total number of cosponsors of the bill or resolution, including any withdrawn cosponsors.
     - `<count>` (e.g. 30)
-      - The current number of cosponsors of the bill or resolution, not including any withdrawn cosponsors. 
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/s/3580/cosponsors)
+      - The current number of cosponsors of the bill or resolution, not including any withdrawn cosponsors.
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/s/3580/cosponsors>)
       - A referrer URL to the cosponsors level of the bill API. Click [here](#cosponsors-level) for more information about the cosponsors level.
 - `<cboCostEstimates>`
   - Container for Congressional Budget Office (CBO) cost estimates associated with a bill or resolution. Read [about CBO](https://www.congress.gov/help/legislative-glossary#glossary_cbo) on Congress.gov.
@@ -146,7 +158,7 @@ Parent container for a bill or resolution. A `<bill>` element may include the fo
           - The date the CBO cost estimate was published.
         - `<title>` (e.g. H.R. 3076, Postal Service Reform Act of 2021)
           - The title of the CBO cost estimate.
-        - `<url>` (e.g. https://www.cbo.gov/publication/57356)
+        - `<url>` (e.g. <https://www.cbo.gov/publication/57356>)
           - The URL for the CBO cost estimate on [CBO.gov](https://www.cbo.gov/).
 - `<laws>`
   - Container for public or private law data for the bill or joint resolution. A `<laws>` element may include the following children:
@@ -155,33 +167,33 @@ Parent container for a bill or resolution. A `<bill>` element may include the fo
       - Possible values are "Public Law" or "Private Law".
     - `<number>` (e.g. 117-108)
       - The law number, as assigned by the National Archives and Records Administration (NARA).
--  `<notes>`
-    - Container for notes attached to the bill or resolution on Congress.gov. The note may contain supplemental information about the bill or resolution that users may find helpful. Read more [about notes](https://www.congress.gov/help/legislative-glossary#glossary_notes) on Congress.gov. 
-    - A `<notes>` element may include the following children:
-      - `<item>`
-        - Container for a note. An `<item>` element may include the following children:
-          - `<text>` (e.g. `<![CDATA[ <a href="https://rules.house.gov/sites/democrats.rules.house.gov/files/BILLS-117HR2471SA-RCP-117-35.pdf" target="_blank">The House Rules Committee Print</a>, <a href="https://docs.house.gov/floor/Default.aspx?date=2022-03-07" target="_blank">joint explanatory statements</a>, and <a href="https://www.congress.gov/congressional-report/117th-congress/house-report/269/1" target="_blank">H.Rept. 117-269</a> from the House Rules Committee are available. ]]>`)
-            - The text of the note on Congress.gov (from https://api.congress.gov/v3/bill/117/hr/2471).
-            - Note that the text is encased in CDATA.
+- `<notes>`
+  - Container for notes attached to the bill or resolution on Congress.gov. The note may contain supplemental information about the bill or resolution that users may find helpful. Read more [about notes](https://www.congress.gov/help/legislative-glossary#glossary_notes) on Congress.gov.
+  - A `<notes>` element may include the following children:
+    - `<item>`
+      - Container for a note. An `<item>` element may include the following children:
+        - `<text>` (e.g. `<![CDATA[ <a href="https://rules.house.gov/sites/democrats.rules.house.gov/files/BILLS-117HR2471SA-RCP-117-35.pdf" target="_blank">The House Rules Committee Print</a>, <a href="https://docs.house.gov/floor/Default.aspx?date=2022-03-07" target="_blank">joint explanatory statements</a>, and <a href="https://www.congress.gov/congressional-report/117th-congress/house-report/269/1" target="_blank">H.Rept. 117-269</a> from the House Rules Committee are available. ]]>`)
+          - The text of the note on Congress.gov (from <https://api.congress.gov/v3/bill/117/hr/2471>).
+          - Note that the text is encased in CDATA.
 - `<policyArea>`
-  - Container for the policy area term of the bill or resolution. Every bill and resolution is assigned one policy area term out of a controlled [field values list](https://www.congress.gov/help/field-values/policy-area) available on Congress.gov. Read more [about policy area terms](https://www.congress.gov/help/legislative-glossary#glossary_policyareaterm) on Congress.gov. 
+  - Container for the policy area term of the bill or resolution. Every bill and resolution is assigned one policy area term out of a controlled [field values list](https://www.congress.gov/help/field-values/policy-area) available on Congress.gov. Read more [about policy area terms](https://www.congress.gov/help/legislative-glossary#glossary_policyareaterm) on Congress.gov.
   - A `<policyArea>` element may include the following children:
     - `<name>` (e.g. Government Operations and Politics)
       - The policy area term assigned to the bill or resolution by CRS.
 - `<subjects>`
-  - Container for legislative subject terms assigned to the bill or resolution by CRS. Read more about [legislative subject terms](https://www.congress.gov/help/find-bills-by-subject) on Congress.gov. 
+  - Container for legislative subject terms assigned to the bill or resolution by CRS. Read more about [legislative subject terms](https://www.congress.gov/help/find-bills-by-subject) on Congress.gov.
   - A `<subjects>` element may include the following children:
     - `<count>` (e.g. 17)
       - The number of legislative subject terms assigned to the bill or resolution by CRS.
-    -  `<url>` (e.g. https://api.congress.gov/v3/bill/hr/3076/subjects)
-        - A referrer URL to the subjects level of the bill API. Click [here](#subjects-level) for more information about the subjects level.
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/hr/3076/subjects>)
+      - A referrer URL to the subjects level of the bill API. Click [here](#subjects-level) for more information about the subjects level.
 - `<summaries>`
   - Container for bill summaries, written by CRS legislative analysts, on the bill or resolution. Read more [about bill summaries](https://www.congress.gov/help/legislative-glossary#glossary_billsummary) on Congress.gov.
   - A `<summaries>` element may include the following children:
     - `<count>` (e.g. 5)
-      - The number of bill summaries on the bill or resolution. 
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/summaries)
-      - A referrer URL to the summaries level of the bill API. Click [here](#summaries-level) for more information about the summaries level. 
+      - The number of bill summaries on the bill or resolution.
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/summaries>)
+      - A referrer URL to the summaries level of the bill API. Click [here](#summaries-level) for more information about the summaries level.
 - `<title>` (e.g. Postal Service Reform Act of 2022)
   - The display title for the bill or resolution on Congress.gov.
   - Read more about [short titles](https://www.congress.gov/help/legislative-glossary#glossary_shorttitle) and [official titles](https://www.congress.gov/help/legislative-glossary#glossary_officialtitle) on Congress.gov.
@@ -189,31 +201,33 @@ Parent container for a bill or resolution. A `<bill>` element may include the fo
   - Container for titles associated with the bill or resolution. A `<titles>` element may include the following children:
     - `<count>` (e.g. 13)
       - The number of titles associated with the bill or resolution. This number may include measure short titles, level short titles, and official titles from the House, Senate, and the Government Publishing Office (GPO).
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/titles)
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/titles>)
       - A referrer URL to the titles level of the bill API. Click [here](#titles-level) for more information about the titles level.
 - `<amendments>`
-  - Container for amendments to the bill or resolution. Read more [about amendments](https://www.congress.gov/help/legislative-glossary#glossary_amendment) on Congress.gov. 
+  - Container for amendments to the bill or resolution. Read more [about amendments](https://www.congress.gov/help/legislative-glossary#glossary_amendment) on Congress.gov.
   - An `<amendments>` element may include the following children:
     - `<count>` (e.g. 48)
       - The number of amendments to the bill or resolution.
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/amendments)
-      - A referrer URL to the amendments level of the bill API. Click [here](#amendments-level) for more information about the amendments level. 
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/amendments>)
+      - A referrer URL to the amendments level of the bill API. Click [here](#amendments-level) for more information about the amendments level.
 - `<textVersions>`
-  - Container for text of the bill or resolution. Read more [About Legislation Text](https://www.congress.gov/help/legislation-text) on Congress.gov. 
+  - Container for text of the bill or resolution. Read more [About Legislation Text](https://www.congress.gov/help/legislation-text) on Congress.gov.
   - A `<textVersions>` element may include the following children:
     - `<count>` (e.g. 7)
       - The number of texts for the bill or resolution.
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/hr/3076/text)
-      - A referrer URL to the text level of the bill API. Click [here](#text-level) for more information about the text level. 
--  `<latestAction>` 
-    - Container for the latest action taken by the House, Senate, or the President on the bill or resolution. A `<latestAction>` element may include the following children:
-      - `<actionDate>` (e.g. 2022-04-06)
-        - The date of the latest action taken on the bill or resolution.
-      - `<text>` (e.g. Became Public Law No: 117-108.)
-        - The text of the latest action taken on the bill or resolution.
-      - `<actionTime>`
-        - The time of the latest action taken on the bill or resolution. Certain actions taken by the House contain this element.
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/hr/3076/text>)
+      - A referrer URL to the text level of the bill API. Click [here](#text-level) for more information about the text level.
+- `<latestAction>`
+  - Container for the latest action taken by the House, Senate, or the President on the bill or resolution. A `<latestAction>` element may include the following children:
+    - `<actionDate>` (e.g. 2022-04-06)
+      - The date of the latest action taken on the bill or resolution.
+    - `<text>` (e.g. Became Public Law No: 117-108.)
+      - The text of the latest action taken on the bill or resolution.
+    - `<actionTime>`
+      - The time of the latest action taken on the bill or resolution. Certain actions taken by the House contain this element.
+
 #### Committees Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -221,16 +235,17 @@ The `<api-root>` is only present in the XML format.
 `<committees>`
 
 Parent container for committees associated with the bill or resolution. A list of committees with an association to data on Congress.gov is available at the [Committee Name History](https://www.congress.gov/help/committee-name-history) page on Congress.gov. A list of current committees is available at [Committees of the U.S. Congress](https://www.congress.gov/committees) on Congress.gov. A `<committees>` element may include the following children:
+
 - `<item>`
   - Container for a committee associated with the bill or resolution. An `<item>` element is repeatable and may include the following children:
-    - `<url>` (e.g. https://api.congress.gov/v3/committee/house/hsif00)
+    - `<url>` (e.g. <https://api.congress.gov/v3/committee/house/hsif00>)
       - A referrer URL to the committee or subcommittee item in the committee API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
     - `<systemCode>` (e.g. hsif00)
       - Unique ID value for the committee.
     - `<name>` (e.g. Energy and Commerce Committee)
-      - The name of the committee or subcommittee associated with the bill or resolution. 
+      - The name of the committee or subcommittee associated with the bill or resolution.
     - `<chamber>` (e.g. House)
-      - The chamber where the committee or subcommittee operates. 
+      - The chamber where the committee or subcommittee operates.
       - Possible values are "House", "Senate", or "Joint".
     - `<type>` (e.g. Standing)
       - The type or status of the committee or subcommittee.
@@ -238,16 +253,18 @@ Parent container for committees associated with the bill or resolution. A list o
     - `<subcommittees>`
       - Container for subcommittees associated with the bill or resolution.
     - `<activities>`
-      - Container for committee or subcommittee activities on a bill or resolution. Read more [about committee-related activity](https://www.congress.gov/help/legislative-glossary#glossary_committeerelatedactivity) on Congress.gov. 
+      - Container for committee or subcommittee activities on a bill or resolution. Read more [about committee-related activity](https://www.congress.gov/help/legislative-glossary#glossary_committeerelatedactivity) on Congress.gov.
       - An `<activities>` element may include the following children:
         - `<item>`
           - Container for a committee or subcommittee activity on a bill or resolution. The `<item>` element is repeatable and may include the following children:
             - `<name>` (e.g. Referred to)
               - The name of the committee or subcommittee activity.
-              - Possible values are "Referred to", "Re-Referred to", "Hearings by", "Markup by", "Reported by", "Reported original measure", "Committed to", "Re-Committed to", and "Legislative Interest". 
+              - Possible values are "Referred to", "Re-Referred to", "Hearings by", "Markup by", "Reported by", "Reported original measure", "Committed to", "Re-Committed to", and "Legislative Interest".
             - `<date>` (e.g. 2021-05-11T18:05:45Z)
               - The date of the committee or subcommittee activity.
+
 #### Related Bills Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -255,18 +272,19 @@ The `<api-root>` is only present in the XML format.
 `<relatedBills>`
 
 Parent container for related bills added by the House, Senate, and CRS. Read more [About Related Bills](https://www.congress.gov/help/related-bills) on Congress.gov. A `<relatedBills>` element may include the following children:
+
 - `<item>`
   - Container for a related bill to the bill or resolution. An `<item>` is repeatable and may element may include the following children:
-    - `<url>` (e.g. https://api.congress.gov/v3/bill/117/s/1720)
+    - `<url>` (e.g. <https://api.congress.gov/v3/bill/117/s/1720>)
       - A referrer URL to the bill item in the API.
     - `<title>` (e.g. Postal Service Reform Act of 2021)
       - The display title for the related bill or resolution on Congress.gov.
     - `<congress>` (e.g. 117)
       - The congress during which the related bill or resolution was introduced or submitted.
-    - `<number>` (e.g. 1720) 
+    - `<number>` (e.g. 1720)
       - The assigned bill or resolution number for the related bill.
     - `<type>` (e.g. S)
-      - The type of related bill or resolution. 
+      - The type of related bill or resolution.
       - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
     - `<latestAction>`
       - Container for the latest action taken on the bill or resolution. A `<latestAction>` element may include the following children:
@@ -276,17 +294,18 @@ Parent container for related bills added by the House, Senate, and CRS. Read mor
           - The text of the latest action taken on the bill or resolution.
         - `<actionTime>`
           - The time of the latest action taken on the bill or resolution. Certain actions taken by the House contain this element.
-     - `<relationshipDetails>` 
-       - Container for the details on the type of relationship added by the House, Senate, or CRS. A `<relationshipDetails>` element may include the following children:
-        - `<item>`
-          - An `<item>` element is repeatable and may include the following children:
-            - `<type>` (e.g. Related bill)
-              - The type of relationship, as designated by the House, Senate, or CRS.
-            - `<identifiedBy>` (e.g. CRS)
-              - The entity responsible for identifying the relationship. 
-              - Possible values are "House", "Senate", and "CRS".
+    - `<relationshipDetails>`
+      - Container for the details on the type of relationship added by the House, Senate, or CRS. A `<relationshipDetails>` element may include the following children:
+      - `<item>`
+        - An `<item>` element is repeatable and may include the following children:
+          - `<type>` (e.g. Related bill)
+            - The type of relationship, as designated by the House, Senate, or CRS.
+          - `<identifiedBy>` (e.g. CRS)
+            - The entity responsible for identifying the relationship.
+            - Possible values are "House", "Senate", and "CRS".
 
 #### Actions Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -294,6 +313,7 @@ The `<api-root>` is only present in the XML format.
 `<actions>`
 
 Parent container for all actions taken on a bill or resolution. Actions may come from the House, Senate, or Library of Congress. An `<actions>` element may include the following children:
+
 - `<item>`
   - Container for an action taken on a bill or resolution. An `<item>` element is repeatable and may include the following children:
     - `<actionDate>` (e.g. 2022-03-08)
@@ -306,11 +326,11 @@ Parent container for all actions taken on a bill or resolution. Actions may come
       - A short name representing legislative process stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent House or Senate legislative process activities.
       - Possible values are "Committee", "Calendars", "Floor", "BecameLaw", "IntroReferral", "President", "ResolvingDifferences", "Discharge", "NotUsed", and "Veto".
     - `<actionCode>`
-      - An action code associated with the action taken on a bill or resolution. 
+      - An action code associated with the action taken on a bill or resolution.
       - The `<actionCode>` element will be present only for actions where the `<sourceSystem>` is 2 (House) or 9 (Library of Congress).
-         - [Action Codes](https://www.congress.gov/help/field-values/action-codes) is an authoritative list of values where the `<sourceSystem>` is 9 (Library of Congress).
-         - An authoritative list of action codes where the `<sourceSystem>` is 2 (House) does not exist.
-       - Various code sets are used by multiple systems in the House, Senate, and Library of Congress by legislative clerks and data editors for functions independent of this data set. As new codes and systems were developed, there was no coordinated effort to retroactively apply new codes to old records. Many codes are concatenated with other codes or elements or utilize free text. Codes in one set may be redundant with a different code in another code set. Additionally, some codes may have been used and re-used over the years for different purposes further complicating the ability to create an authoritative list. View the original code set of [U.S. Congress legislative status steps](http://www.loc.gov/pictures/resource/ppmsca.33996/).
+        - [Action Codes](https://www.congress.gov/help/field-values/action-codes) is an authoritative list of values where the `<sourceSystem>` is 9 (Library of Congress).
+        - An authoritative list of action codes where the `<sourceSystem>` is 2 (House) does not exist.
+      - Various code sets are used by multiple systems in the House, Senate, and Library of Congress by legislative clerks and data editors for functions independent of this data set. As new codes and systems were developed, there was no coordinated effort to retroactively apply new codes to old records. Many codes are concatenated with other codes or elements or utilize free text. Codes in one set may be redundant with a different code in another code set. Additionally, some codes may have been used and re-used over the years for different purposes further complicating the ability to create an authoritative list. View the original code set of [U.S. Congress legislative status steps](http://www.loc.gov/pictures/resource/ppmsca.33996/).
     - `<sourceSystem>`
       - Container for the source system where the action was entered. A `<sourceSystem>` element may include the following children:
         - `<code>` (e.g. 0)
@@ -320,43 +340,45 @@ Parent container for all actions taken on a bill or resolution. Actions may come
         - `<name>` (e.g. Senate)
           - The name of the source system that entered the action.
           - Possible values are "Senate", "House committee actions", "House floor actions", and "Library of Congress".
-     - `<committees>`
-       - Container for committees associated with the action. A `<committees>` element may include the following children:
-          - `<item>`
-            - Container for a committee associated with the action. An `<item>` element is repeatable and may include the following children:
-              - `<url>`
-                - A referrer URL to the committee or subcommittee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
-              - `<systemCode>`
-                - A code associated with the committee or subcommittee used to match items in Congress.gov with the committee or subcommittee.
-              - `<name>`
-                - The name of the committee or subcommittee associated with the action.
-     - `<recordedVotes>`
-       - Container for recorded (roll call) votes associated with the action. Read more [about roll call votes](https://www.congress.gov/help/legislative-glossary#glossary_rollcallvote) on Congress.gov. More information can also be found at the [Roll Call Votes by the U.S. Congress](https://www.congress.gov/roll-call-votes) and [Votes in the House and Senate](https://www.congress.gov/help/votes-in-the-house-and-senate) pages on Congress.gov. 
-       - A `<recordedVotes>` element may include the following children:
-         - `<recordedVote>` 
-           - Container for a recorded (roll call) vote associated with the action. A `<recordedVote>` element may include the following children:
-             - `<rollNumber>` (e.g. 70)
-                - The recorded (roll call) vote number.
-             - `<url>` (e.g. https://www.senate.gov/legislative/LIS/roll_call_votes/vote1172/vote_117_2_00070.xml)
-                - The url to the recorded (roll call) vote on [Senate.gov](https://www.senate.gov/legislative/votes_new.htm) or [Clerk.House.gov](https://clerk.house.gov/Votes).
-                - Note that the provided URL is for the XML format of the recorded (roll call) vote. 
-             - `<chamber>` (e.g. Senate)
-               - The chamber where the recorded (roll call) vote took place.
-               - Possible values are "House" and "Senate".
-             - `<congress>` (e.g. 117)
-               - The congress during which the recorded (roll call) vote took place.
-             - `<date>` (e.g. 2022-03-08T22:45:05Z)
-               - The date of the recorded (roll call) vote.
-             - `<sessionNumber>` (e.g. 2)
-               - The session of congress during which the recorded (roll call) vote took place.
-     - `<calendarNumber>`
-       - Container for calendar information associated with the action. Read more [about calendars](https://www.congress.gov/help/legislative-glossary#glossary_calendar) on Congress.gov.
-       - A `<calendarNumber>` element may include the following children:
-         - `<calendar>` 
-           - The calendar name (e.g. Senate Calendar of Business, U00171) associated with the action.
-         - `<number>`
-           - The Senate calendar number. Actions from the House associated with a calendar will not have a number value populated in this field.
+    - `<committees>`
+      - Container for committees associated with the action. A `<committees>` element may include the following children:
+        - `<item>`
+          - Container for a committee associated with the action. An `<item>` element is repeatable and may include the following children:
+            - `<url>`
+              - A referrer URL to the committee or subcommittee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
+            - `<systemCode>`
+              - A code associated with the committee or subcommittee used to match items in Congress.gov with the committee or subcommittee.
+            - `<name>`
+              - The name of the committee or subcommittee associated with the action.
+    - `<recordedVotes>`
+      - Container for recorded (roll call) votes associated with the action. Read more [about roll call votes](https://www.congress.gov/help/legislative-glossary#glossary_rollcallvote) on Congress.gov. More information can also be found at the [Roll Call Votes by the U.S. Congress](https://www.congress.gov/roll-call-votes) and [Votes in the House and Senate](https://www.congress.gov/help/votes-in-the-house-and-senate) pages on Congress.gov.
+      - A `<recordedVotes>` element may include the following children:
+        - `<recordedVote>`
+          - Container for a recorded (roll call) vote associated with the action. A `<recordedVote>` element may include the following children:
+            - `<rollNumber>` (e.g. 70)
+              - The recorded (roll call) vote number.
+            - `<url>` (e.g. <https://www.senate.gov/legislative/LIS/roll_call_votes/vote1172/vote_117_2_00070.xml>)
+              - The url to the recorded (roll call) vote on [Senate.gov](https://www.senate.gov/legislative/votes_new.htm) or [Clerk.House.gov](https://clerk.house.gov/Votes).
+              - Note that the provided URL is for the XML format of the recorded (roll call) vote.
+            - `<chamber>` (e.g. Senate)
+              - The chamber where the recorded (roll call) vote took place.
+              - Possible values are "House" and "Senate".
+            - `<congress>` (e.g. 117)
+              - The congress during which the recorded (roll call) vote took place.
+            - `<date>` (e.g. 2022-03-08T22:45:05Z)
+              - The date of the recorded (roll call) vote.
+            - `<sessionNumber>` (e.g. 2)
+              - The session of congress during which the recorded (roll call) vote took place.
+    - `<calendarNumber>`
+      - Container for calendar information associated with the action. Read more [about calendars](https://www.congress.gov/help/legislative-glossary#glossary_calendar) on Congress.gov.
+      - A `<calendarNumber>` element may include the following children:
+        - `<calendar>`
+          - The calendar name (e.g. Senate Calendar of Business, U00171) associated with the action.
+        - `<number>`
+          - The Senate calendar number. Actions from the House associated with a calendar will not have a number value populated in this field.
+
 #### Cosponsors Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -364,43 +386,45 @@ The `<api-root>` is only present in the XML format.
 `<cosponsors>`
 
 Parent container for cosponsors of a bill or resolution. Read more [about cosponsors](https://www.congress.gov/help/legislative-glossary#glossary_cosponsor) on Congress.gov. A `<cosponsors>` element may include the following children:
+
 - `<item>`
   - Container for a cosponsor of a bill or resolution. An `<item>` element is repeatable and may include the following children:
     - `<bioguideId>` (e.g. C001078)
       - The unique identifier for the bill or resolution cosponsor, as assigned in the [Biographical Directory of the United States Congress, 1774-Present](http://bioguide.congress.gov/).
-      - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov. 
-     - `<fullName>` (e.g. Rep. Connolly, Gerald E. [D-VA-11])
-        - The display name for the bill or resolution cosponsor.
-     - `<firstName>` (e.g. Gerald)
-        - The first name of the bill or resolution cosponsor.
-     - `<middleName>` (e.g. E.)
-        - The middle name or initial of the bill or resolution cosponsor. 
-     - `<lastName>` (e.g. Connolly)
-        - The last name of the bill or resolution cosponsor. 
-     - `<party>` (e.g. D)
-        - The party code of the bill or resolution cosponsor.
-        - Possible values are "D", "R", "I", "ID", and "L".
-     - `<state>` (e.g. VA)
-        - A two-letter abbreviation for the state, territory, or district represented by the bill or resolution cosponsor. 
-     - `<url>` (e.g. https://api.congress.gov/v3/member/C001078)
-        - A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
-     - `<district>` (e.g. 11)
-        - The congressional district that the bill or resolution sponsor represents. 
-        - Note that this element will be "0" for states, territories, or districts where there is only one congressional district.
-     - `<sponsorshipDate>` (e.g. 2021-05-11)
-        - The date the member became a cosponsor of the bill or resolution.
-     - `<isOriginalCosponsor>` (e.g. True)
-        - A designation that the member is an original or additional cosponsor of the bill or resolution. If the member cosponsored the bill or resolution on the date of its introduction or submission, then this value will be "True". If the member cosponsored the bill or resolution after its date of introduction or submission, then this value will be "False". 
-        - Possible values are "True" or "False"
+      - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
+    - `<fullName>` (e.g. Rep. Connolly, Gerald E. [D-VA-11])
+      - The display name for the bill or resolution cosponsor.
+    - `<firstName>` (e.g. Gerald)
+      - The first name of the bill or resolution cosponsor.
+    - `<middleName>` (e.g. E.)
+      - The middle name or initial of the bill or resolution cosponsor.
+    - `<lastName>` (e.g. Connolly)
+      - The last name of the bill or resolution cosponsor.
+    - `<party>` (e.g. D)
+      - The party code of the bill or resolution cosponsor.
+      - Possible values are "D", "R", "I", "ID", and "L".
+    - `<state>` (e.g. VA)
+      - A two-letter abbreviation for the state, territory, or district represented by the bill or resolution cosponsor.
+    - `<url>` (e.g. <https://api.congress.gov/v3/member/C001078>)
+      - A referrer URL to the member item in the API. Documentation for the member endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
+    - `<district>` (e.g. 11)
+      - The congressional district that the bill or resolution sponsor represents.
+      - Note that this element will be "0" for states, territories, or districts where there is only one congressional district.
+    - `<sponsorshipDate>` (e.g. 2021-05-11)
+      - The date the member became a cosponsor of the bill or resolution.
+    - `<isOriginalCosponsor>` (e.g. True)
+      - A designation that the member is an original or additional cosponsor of the bill or resolution. If the member cosponsored the bill or resolution on the date of its introduction or submission, then this value will be "True". If the member cosponsored the bill or resolution after its date of introduction or submission, then this value will be "False".
+      - Possible values are "True" or "False"
     - `<sponsorshipWithdrawnDate>`
-        - The date the cosponsor withdrew their cosponsorship of the bill or resolution.
-- `<pagination>` (from https://api.congress.gov/v3/bill/117/s/3580/cosponsors)
+      - The date the cosponsor withdrew their cosponsorship of the bill or resolution.
+- `<pagination>` (from <https://api.congress.gov/v3/bill/117/s/3580/cosponsors>)
   - `<count>` (e.g. 30)
     - The current count of cosponsors of the bill or resolution, not including any withdrawn cosponsors.
   - `<countIncludingWithdrawnCosponsors>` (e.g. 31)
-    - The total number of cosponsors of the bill or resolution, including any withdrawn cosponsors. 
+    - The total number of cosponsors of the bill or resolution, including any withdrawn cosponsors.
 
 #### Subjects Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -408,44 +432,49 @@ The `<api-root>` is only present in the XML format.
 `<subjects>`
 
 Parent container for [legislative subject terms](https://www.congress.gov/help/legislative-glossary#glossary_legislativesubjectterm) and [policy area terms](https://www.congress.gov/help/legislative-glossary#glossary_policyareaterm) attached to a bill or resolution, as assigned by CRS. Note that subject terms from the [Legislative Indexing Vocabulary](https://www.congress.gov/help/legislative-glossary#glossary_legislativeindexingvocabulary) were applied to bills and resolutions from the 93rd to the 110th Congresses (1973-2008). Read more [about subject and policy area terms](https://www.congress.gov/help/find-bills-by-subject) on Congress.gov. A `<subjects>` element may include the following children:
+
 - `<legislativeSubjects>`
   - Container for legislative subject terms attached to a bill or resolution. A `<legislativeSubjects>` element may include the following children:
-     - `<item>` 
-        - Container for a legislative subject term attached to a bill or resolution. An `<item>` element is repeatable and may include the following children:
-          - `<name>` (e.g. Congressional oversight)
-              - The name of the legislative subject term attached to a bill or resolution. 
+    - `<item>`
+      - Container for a legislative subject term attached to a bill or resolution. An `<item>` element is repeatable and may include the following children:
+        - `<name>` (e.g. Congressional oversight)
+          - The name of the legislative subject term attached to a bill or resolution.
 - `<policyArea>`
-  - Container for the policy area term attached to a bill or resolution. Each bill or resolution will have only one policy area term taken from [this list of terms](https://www.congress.gov/help/field-values/policy-area) on Congress.gov. 
+  - Container for the policy area term attached to a bill or resolution. Each bill or resolution will have only one policy area term taken from [this list of terms](https://www.congress.gov/help/field-values/policy-area) on Congress.gov.
   - Note that prior to the 101st Congress (1989), terms outside of the controlled list may be used as a policy area term for a bill or resolution. Projects are underway to standardize the terms used during those congresses.
   - A `<policyArea>` element may include the following children:
-      - `<name>` (e.g. Government Operations and Politics)
-        - The name of the policy area term attached to a bill or resolution.
+    - `<name>` (e.g. Government Operations and Politics)
+      - The name of the policy area term attached to a bill or resolution.
 
 #### Summaries Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
 `<summaries>`
 
-Parent container for bill summaries on the bill or resolution. Bill summaries are written by legislative analysts in CRS. Read more [about bill summaries](https://www.congress.gov/help/legislative-glossary#glossary_billsummary) on Congress.gov. Read more about the summaries endpoint [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/SummariesEndpoint.md). 
+Parent container for bill summaries on the bill or resolution. Bill summaries are written by legislative analysts in CRS. Read more [about bill summaries](https://www.congress.gov/help/legislative-glossary#glossary_billsummary) on Congress.gov. Read more about the summaries endpoint [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/SummariesEndpoint.md).
 
 A `<summaries>` element may include the following children:
+
 - `<summary>`
   - Container for a bill summary on the bill or resolution. A `<summary>` element may include the following children:
     - `<versionCode>` (e.g. 00)
-      - The internal code used by CRS to tag its summaries according to the action associated with the summary. 
-      - Click [here](#bill-summary-version-codes-action-descriptions-and-chamber) for a list of codes. Note that the version codes have varied over time. 
+      - The internal code used by CRS to tag its summaries according to the action associated with the summary.
+      - Click [here](#bill-summary-version-codes-action-descriptions-and-chamber) for a list of codes. Note that the version codes have varied over time.
     - `<actionDate>` (e.g. 2021-05-11)
-      - The date of action associated with the bill summary. 
-    -  `<actionDesc>` (e.g. Introduced in House)
-       - The description of the action associated with the bill summary.
+      - The date of action associated with the bill summary.
+    - `<actionDesc>` (e.g. Introduced in House)
+      - The description of the action associated with the bill summary.
     - `<updateDate>` (e.g. 2021-06-07T20:24:30Z)
-        - The update date for the bill summary on Congress.gov. This may be the date the summary was published or re-published. 
+      - The update date for the bill summary on Congress.gov. This may be the date the summary was published or re-published.
     - `<text>` (e.g. `<![CDATA[ <p><strong>Postal Service Reform Act of 2021</strong></p> <p>This bill addresses the finances and operations of the U.S. Postal Service (USPS).</p> <p>The bill requires the Office of Personnel Management to establish the Postal Service Health Benefits Program for USPS employees and retirees and provides for coordinated enrollment of retirees under this program and Medicare. The bill repeals the requirement that the USPS annually prepay future retirement health benefits.</p> <p>Additionally, the USPS may establish a program to enter into agreements with an agency of any state government, local government, or tribal government, and with other government agencies, to provide certain nonpostal products and services that reasonably contribute to the costs of the USPS and meet other specified criteria.</p> <p>The USPS must develop and maintain a publicly available dashboard to track service performance and must report regularly on its operations and financial condition.</p> <p>The Postal Regulatory Commission must annually submit to the USPS a budget of its expenses. It must also conduct a study to identify the causes and effects of postal inefficiencies relating to flats (e.g., large envelopes).</p> <p>The USPS Office of Inspector General shall perform oversight of the Postal Regulatory Commission.</p> <ul> <ul> </ul> </ul> ]]>`)
       - The text of the bill summary.
       - Note that the text is encased in CDATA and contains HTML codes (e.g. `<p>`). The HTML codes may not be valid (see [#2](https://github.com/LibraryOfCongress/api.congress.gov/issues/2)); efforts are underway to improve the validity of the HTML codes.
+
 ##### Bill summary version codes, action descriptions, and chamber
+
 | versionCode | actionDesc | chamber |
 | ----------- | ---------- | ------- |
 | 00 | Introduced in House | House |
@@ -509,6 +538,7 @@ A `<summaries>` element may include the following children:
 | 87 | Conference report filed in House, 3rd conference report | House |
 
 #### Titles Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -516,24 +546,26 @@ The `<api-root>` is only present in the XML format.
 `<titles>`
 
 Parent container for titles associated with the bill or resolution. A title may be an [official title](https://www.congress.gov/help/legislative-glossary#glossary_officialtitle), a [short title](https://www.congress.gov/help/legislative-glossary#glossary_shorttitle), or a [popular title](https://www.congress.gov/help/legislative-glossary#glossary_populartitle). A `<titles>` element may include the following children:
+
 - `<item>`
   - Container for a title associated with the bill or resolution. An `<item>` element is repeatable and may include the following children:
     - `<titleType>` (e.g. Short Title(s) as Passed House)
-      - A short description of the type of title associated with the bill or resolution. 
+      - A short description of the type of title associated with the bill or resolution.
     - `<title>` (e.g. Postal service Reform Act of 2022)
-      - The text of the title associated with the bill or resolution. 
-    -  `<chamberCode>` (e.g. H)
-       - The chamber code associated with the title. This element is not populated for all titles (e.g. a display title will never have an associated chamber).
-       - Possible values are "H" and "S".
-    -  `<chamberName>` (e.g. House)
-       - The name of the chamber associated with the title. This element is not populated for all titles (e.g. a display title will never have an associated chamber).
-       - Possible values are "House" and "Senate".
+      - The text of the title associated with the bill or resolution.
+    - `<chamberCode>` (e.g. H)
+      - The chamber code associated with the title. This element is not populated for all titles (e.g. a display title will never have an associated chamber).
+      - Possible values are "H" and "S".
+    - `<chamberName>` (e.g. House)
+      - The name of the chamber associated with the title. This element is not populated for all titles (e.g. a display title will never have an associated chamber).
+      - Possible values are "House" and "Senate".
     - `<billTextVersionName>` (e.g. Engrossed in House)
-        - The name of the bill text version associated with the title. This element is not populated for all titles (e.g. a display title will never have an associated bill text version). 
+      - The name of the bill text version associated with the title. This element is not populated for all titles (e.g. a display title will never have an associated bill text version).
     - `<billTextVersionCode>` (e.g. EH)
-        - The file extension code for the bill text version associated with the title. This element is not populate for all titles (e.g. a display title will never have an associated bill text version).
+      - The file extension code for the bill text version associated with the title. This element is not populate for all titles (e.g. a display title will never have an associated bill text version).
 
 #### Text Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -541,6 +573,7 @@ The `<api-root>` is only present in the XML format.
 `<textVersions>`
 
 Parent container for text versions associated with the bill or resolution. Read more about bill text at [About Legislation Text of the U.S. Congress](https://www.congress.gov/help/legislation-text). A `<textVersions>` element may include the following children:
+
 - `<item>`
   - Container for a text version associated with the bill or resolution. An `<item>` element is repeatable and may include the following children:
     - `<type>` (e.g. Introduced in House)
@@ -548,15 +581,17 @@ Parent container for text versions associated with the bill or resolution. Read 
     - `<date>` (e.g. 2021-05-11T04:00:00Z)
       - The date associated with the text version. This date is associated with the date of action, not the printing date.
     - `<formats>`
-      - Container for formats of the text version. A `<formats>` element may include the following children: 
-        - `<item>` 
+      - Container for formats of the text version. A `<formats>` element may include the following children:
+        - `<item>`
           - Container for a format of the text version. An `<item>` element is repeatable and may include the following children:
-            - `<url>` (e.g. https://www.congress.gov/117/bills/hr3076/BILLS-117hr3076ih.xml)
-              - The URL for the text version format in Congress.gov. 
+            - `<url>` (e.g. <https://www.congress.gov/117/bills/hr3076/BILLS-117hr3076ih.xml>)
+              - The URL for the text version format in Congress.gov.
             - `<type>` (e.g. Formatted XML)
-              -  The type of bill text version format. 
-              -  Possible values are "Formatted Text", "PDF", and "Formatted XML". Note that not all format types are available for all text versions.
+              - The type of bill text version format.
+              - Possible values are "Formatted Text", "PDF", and "Formatted XML". Note that not all format types are available for all text versions.
+
 #### Amendments Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -564,28 +599,29 @@ The `<api-root>` is only present in the XML format.
 `<amendments>`
 
 Parent container for amendments on the bill or resolution. Read more [about amendments](https://www.congress.gov/help/legislative-glossary#glossary_amendment) on Congress.gov. An `<amendments>` element may include the following children:
+
 - `<amendment>`
   - Container for an amendment on the bill or resolution. An `<amendment>` element is repeatable and may include the following children:
     - `<number>` (e.g. 173)
       - The assigned amendment number.
     - `<description>` (e.g. An amendment numbered 1 printed in House Report 117-243 to clarifiy the roles and responsibilities of the Office of Personnel Management, the Social Security Administration, and the Centers for Medicare & Medicaid Services regarding the information postal employees will need to enroll in Medicare Part B; specify that performance standards must be submitted to the Postal Regulatory Commission for each product; and make other technical and conforming changes to the bill.)
-      - The amendment's description. 
+      - The amendment's description.
       - Only House amendments will have this element populated.
     - `<purpose>`
-      - The amendment's purpose. 
+      - The amendment's purpose.
       - House amendments and proposed Senate amendments may have this element populated.
     - `<congress>` (e.g. 117)
-      - The congress during which the amendment was submitted or offered. 
+      - The congress during which the amendment was submitted or offered.
     - `<type>` (e.g. HAMDT)
       - The type of amendment.
       - Possible values are "HAMDT", "SAMDT", and "SUAMDT". Note that the "SUAMDT" type value is only available for the 97th and 98th Congresses.
     - `<latestAction>`
       - Container for the latest action taken on the amendment. A `<latestAction>` element may include the following children:
-          - `<actionDate>` (e.g. 2022-02-08)
-            - The date of the latest action taken on the amendment.
-          - `<text>` (e.g. On agreeing to the Maloney, Carolyn B. amendment (A002) Agreed to by voice vote.)
-            - The text of the latest action taken on the amendment.
+        - `<actionDate>` (e.g. 2022-02-08)
+          - The date of the latest action taken on the amendment.
+        - `<text>` (e.g. On agreeing to the Maloney, Carolyn B. amendment (A002) Agreed to by voice vote.)
+          - The text of the latest action taken on the amendment.
       - `<actionTime>` (e.g. 15:39:53)
         - The time of the latest action taken on the amendment. Certain actions taken by the House contain this element.
-    - `<url>` (e.g. https://api.congress.gov/v3/amendment/117/hamdt/173)
+    - `<url>` (e.g. <https://api.congress.gov/v3/amendment/117/hamdt/173>)
       - A referrer URL to the amendment item in the API. Documentation for the amendment endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/AmendmentEndpoint.md).

--- a/Documentation/BriefEndpointsDocumentation.md
+++ b/Documentation/BriefEndpointsDocumentation.md
@@ -1,5 +1,7 @@
-This documentation provides a brief overview of available endpoints in the Congress.gov API, including the base request, item level, and any deeper levels. Links to expanded documentation on the endpoints are provided in the **Coverage** text. 
 # Jump to
+
+This documentation provides a brief overview of available endpoints in the Congress.gov API, including the base request, item level, and any deeper levels. Links to expanded documentation on the endpoints are provided in the **Coverage** text.
+
 - [bill](#bill)
 - [amendment](#amendment)
 - [summaries](#summaries)
@@ -13,108 +15,210 @@ This documentation provides a brief overview of available endpoints in the Congr
 - [house-communication](#house-communication)
 - [house-requirement](#house-requirement)
 - [senate-communication](#senate-communication)
-# Endpoints
+
+## Endpoints
+
 ## bill
+
 ### Coverage
+
 Coverage information for bill data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Projects to add more historical legislative data to Congress.gov are underway. Read more about bill data at [About Legislation of the U.S. Congress](https://www.congress.gov/help/legislation). View expanded documentation for the bill endpoints at [BillEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
+
 ### Base Request
-The base request for bill data in the API is https://api.congress.gov/v3/bill. The request will return 20 results by default. Basic information about each bill item will be included in the response. Included in that basic information is the congress (e.g. 117), bill type (e.g. HR), bill number (e.g. 3076), origin chamber (e.g. House), a URL to the bill item in the API (e.g. https://api.congress.gov/v3/bill/117/hr/3076), title (e.g. Postal Service Reform Act of 2022), latest action (e.g. Became Public Law No: 117-108.), and the bill's update date in Congress.gov (e.g. 2022-06-28T22:30:22Z). Filters can be added to the URL in order to limit results returned to bills in a single Congress (e.g. https://api.congress.gov/v3/bill/117) or congress and bill type (e.g. https://api.congress.gov/v3/bill/117/hr).
+
+The base request for bill data in the API is <https://api.congress.gov/v3/bill>. The request will return 20 results by default. Basic information about each bill item will be included in the response. Included in that basic information is the congress (e.g. 117), bill type (e.g. HR), bill number (e.g. 3076), origin chamber (e.g. House), a URL to the bill item in the API (e.g. <https://api.congress.gov/v3/bill/117/hr/3076>), title (e.g. Postal Service Reform Act of 2022), latest action (e.g. Became Public Law No: 117-108.), and the bill's update date in Congress.gov (e.g. 2022-06-28T22:30:22Z). Filters can be added to the URL in order to limit results returned to bills in a single Congress (e.g. <https://api.congress.gov/v3/bill/117>) or congress and bill type (e.g. <https://api.congress.gov/v3/bill/117/hr>).
+
 ### Item
+
 Depending on the data available, each bill item in the API may contain the following: congress (e.g. 117), bill type (e.g. HR), bill number (e.g. 3076), origin chamber (e.g. House), introduced date (e.g. 2021-05-11), title[^1] (e.g. Postal Service Reform Act of 2022), constitutional authority statement, committee count, associated committee report(s)[^2], related bills[^3] count, actions count, sponsor (e.g. Rep. Maloney, Carolyn B. [D-NY-12]), cosponsor count (e.g. 102), associated Congressional Budget Office (CBO) cost estimate(s)[^4], law information (e.g. Public Law, 116-108), policy area term[^5] (e.g. Government Operations and Politics), subjects[^6] count (e.g. 17), summaries[^7] count (e.g. 5), amendments count (e.g. 48), text count (e.g. 7), latest action (e.g. Became Public Law No: 117-108.), and the bill’s update date in Congress.gov.
+
 ### Levels
-Depending on the data available, each bill item in the API may contain a referrer URL to the following deeper levels: actions, amendments, committees, cosponsors, relatedBills[^3], subjects[^6], summaries[^7], text[^8], and titles[^1]. These levels contain more information related to the bill item. For example, the actions level may contain the following for each action on the bill: date of action (e.g. 2022-03-28), text of the action (e.g. Became Public Law No: 117-108.), the type of action (e.g. BecameLaw), action code[^9] (e.g. 36000), source system (e.g. Library of Congress), associated committee information, associated recorded vote information, and associated calendar information. 
+
+Depending on the data available, each bill item in the API may contain a referrer URL to the following deeper levels: actions, amendments, committees, cosponsors, relatedBills[^3], subjects[^6], summaries[^7], text[^8], and titles[^1]. These levels contain more information related to the bill item. For example, the actions level may contain the following for each action on the bill: date of action (e.g. 2022-03-28), text of the action (e.g. Became Public Law No: 117-108.), the type of action (e.g. BecameLaw), action code[^9] (e.g. 36000), source system (e.g. Library of Congress), associated committee information, associated recorded vote information, and associated calendar information.
+
 ## amendment
+
 ### Coverage
+
 Coverage information for amendment data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more about [amendments on Congress.gov](https://www.congress.gov/help/legislative-glossary#glossary_amendment). View expanded documentation for the amendment endpoints at [AmendmentEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/AmendmentEndpoint.md).
+
 ### Base Request
-The base request for amendment data in the Congress.gov API is https://api.congress.gov/v3/amendment. The request will return 20 results by default. Basic information about each amendment item will be included in the response. Included in the basic information is the congress (e.g. 117), amendment type (e.g. SAMDT), amendment number (e.g. 2137), description, purpose (e.g. In the nature of a substitute.), latest action (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.), and a URL to the amendment item in the API (e.g. https://api.congress.gov/v3/amendment/117/samdt/2137). Filters can be added to the URL in order to limit results returned to amendments in a single congress (e.g. https://api.congress.gov/v3/amendment/117) or congress and amendment type (e.g. https://api.congress.gov/v3/amendment/117/samdt).
+
+The base request for amendment data in the Congress.gov API is <https://api.congress.gov/v3/amendment>. The request will return 20 results by default. Basic information about each amendment item will be included in the response. Included in the basic information is the congress (e.g. 117), amendment type (e.g. SAMDT), amendment number (e.g. 2137), description, purpose (e.g. In the nature of a substitute.), latest action (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.), and a URL to the amendment item in the API (e.g. <https://api.congress.gov/v3/amendment/117/samdt/2137>). Filters can be added to the URL in order to limit results returned to amendments in a single congress (e.g. <https://api.congress.gov/v3/amendment/117>) or congress and amendment type (e.g. <https://api.congress.gov/v3/amendment/117/samdt>).
+
 ### Item
+
 Depending on the data available, each amendment item in the API may contain the following: congress (e.g. 117), amendment type (e.g. SAMDT), amendment number (e.g. 2137), purpose (e.g. In the nature of a substitute.), description, latest action (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.), the amendment’s update date in Congress.gov (e.g. 2022-02-08T17:27:59Z), sponsor (e.g. Sen. Sinema, Kyrsten [D-AZ]), cosponsor count (e.g. 9), amended bill information (e.g. 117 HR 3684), amended amendments information, amendments to the amendment count (e.g. 507), amended treaty information, and an actions count (e.g. 19).
+
 ### Levels
-Depending on the data available, each amendment item in the API may contain a referrer URL to the following deeper levels: actions, amendments (to the amendment), and cosponsors. These levels contain more information related to the amendment item. For example, the actions level may contain the following for each action on the amendment: date of action (e.g. 2021-08-08), text of the action (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.), the type of action (e.g. Floor), action code[^9], source system (e.g. Senate), associated committee information and associated recorded vote information. 
+
+Depending on the data available, each amendment item in the API may contain a referrer URL to the following deeper levels: actions, amendments (to the amendment), and cosponsors. These levels contain more information related to the amendment item. For example, the actions level may contain the following for each action on the amendment: date of action (e.g. 2021-08-08), text of the action (e.g. Amendment SA 2137 agreed to in Senate by Yea-Nay Vote. 69 - 28. Record Vote Number: 312.), the type of action (e.g. Floor), action code[^9], source system (e.g. Senate), associated committee information and associated recorded vote information.
+
 ## summaries
+
 ### Coverage
+
 Coverage information for bill summaries data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). By default, only bill summaries published in the last day are available from these endpoints unless "fromDateTime" and/or "toDateTime" parameters are added to the API request (read more about those parameters in the [OpenAPI Specification](https://api.congress.gov/#/summaries/bill_summaries_all)); however, all bill summaries published for bills available on Congress.gov can be found at the [bill endpoints](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md#summaries-level). View expanded documentation for the summaries endpoints at [SummariesEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/SummariesEndpoint.md).
+
 ### Base Request
-The base request for bill summary data in the Congress.gov API is https://api.congress.gov/v3/summaries. The request will return 20 results by default. Basic information on each bill summary item will be included in the response. Included in the basic information is the associated bill or resolution, the text of the bill summary, and related data on the bill summary, such as action description, action date, update date, and summary version code.
+
+The base request for bill summary data in the Congress.gov API is <https://api.congress.gov/v3/summaries>. The request will return 20 results by default. Basic information on each bill summary item will be included in the response. Included in the basic information is the associated bill or resolution, the text of the bill summary, and related data on the bill summary, such as action description, action date, update date, and summary version code.
+
 ## congress
+
 ### Coverage
-Coverage information for congress data in the API can be found at the [Congresses field values list](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Information on past session dates can be found on Congress.gov at the [Dates of Past Sessions](https://www.congress.gov/past-days-in-session). View expanded documentation for the congress endpoints at [CongressEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CongressEndpoint.md). 
+
+Coverage information for congress data in the API can be found at the [Congresses field values list](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Information on past session dates can be found on Congress.gov at the [Dates of Past Sessions](https://www.congress.gov/past-days-in-session). View expanded documentation for the congress endpoints at [CongressEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CongressEndpoint.md).
+
 ### Base Request
-The base request for congress data in the API is https://api.congress.gov/v3/congress. The request will return 20 results by default. Basic information about each congress item will be included in the request. Included in that basic information is the congress's name (e.g. 117th Congress), start year (e.g. 2021), end year (e.g. 2022), session data (including session type - e.g. Regular - and chamber - e.g. House of Representatives), and a URL to the congress item in the API (e.g. https://api.congress.gov/v3/congress/117). 
+
+The base request for congress data in the API is <https://api.congress.gov/v3/congress>. The request will return 20 results by default. Basic information about each congress item will be included in the request. Included in that basic information is the congress's name (e.g. 117th Congress), start year (e.g. 2021), end year (e.g. 2022), session data (including session type - e.g. Regular - and chamber - e.g. House of Representatives), and a URL to the congress item in the API (e.g. <https://api.congress.gov/v3/congress/117>).
+
 ### Item
-Depending on the data available, each congress item in the API may contain the following: the congress's name (e.g. 117th Congress), start year (e.g. 2021), end year (e.g. 2022), update date in Congress.gov (e.g. 2021-01-12T20:05:52Z), congress number (e.g. 117), and sessions data. Sessions data may contain the following: chamber (e.g. House of Representatives), type of session (e.g. R, for "Regular"), start date (2021-01-03), end date (e.g. 2022-01-03), and session number (e.g. 1). 
+
+Depending on the data available, each congress item in the API may contain the following: the congress's name (e.g. 117th Congress), start year (e.g. 2021), end year (e.g. 2022), update date in Congress.gov (e.g. 2021-01-12T20:05:52Z), congress number (e.g. 117), and sessions data. Sessions data may contain the following: chamber (e.g. House of Representatives), type of session (e.g. R, for "Regular"), start date (2021-01-03), end date (e.g. 2022-01-03), and session number (e.g. 1).
+
 ## member
+
 ### Coverage
+
 Coverage information for member data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more about member data at [About Congressional Member Profiles](https://www.congress.gov/help/members). View expanded documentation for the member endpoints at [MemberEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/MemberEndpoint.md).
+
 ### Base Request
-The base request for member data in the API is https://api.congress.gov/v3/member. The request will return 20 results by default. Basic information about each member item will be included the response. Included in that basic information is the member's Bioguide identifier (e.g. L000174), state (e.g. Vermont), party (e.g. Democratic), district, name (e.g. Leahy, Patrick J.), chamber/years served (including the chamber - e.g. Senate, start year of service in that chamber - e.g. 1975, and end year of service in that chamber), a URL to the member item in the API (e.g. https://api.congress.gov/v3/member/L000174), and member image data (including an image URL and attribution). 
+
+The base request for member data in the API is <https://api.congress.gov/v3/member>. The request will return 20 results by default. Basic information about each member item will be included the response. Included in that basic information is the member's Bioguide identifier (e.g. L000174), state (e.g. Vermont), party (e.g. Democratic), district, name (e.g. Leahy, Patrick J.), chamber/years served (including the chamber - e.g. Senate, start year of service in that chamber - e.g. 1975, and end year of service in that chamber), a URL to the member item in the API (e.g. <https://api.congress.gov/v3/member/L000174>), and member image data (including an image URL and attribution).
+
 ### Item
-Depending on the data available, each member item in the API may contain the following: the member's status (current or not current), birth year (e.g. 1940), death year, an update date in Congress.gov (e.g. 2022-05-17T18:44:02Z), member image data (including an image URL and attribution), member term data (including the member type - Senator, congress served - 117, state represented - Vermont, party information - Democratic, term start year - 2021, and term end year), party data (e.g. Democratic), state data (e.g. Vermont), official website URL (e.g. https://www.leahy.senate.gov/), name information (e.g. Leahy, Patrick J.), office address (e.g. 437 Russell Senate Office Building Washington, DC 20510) and contact information (e.g. (202) 224-4242).
+
+Depending on the data available, each member item in the API may contain the following: the member's status (current or not current), birth year (e.g. 1940), death year, an update date in Congress.gov (e.g. 2022-05-17T18:44:02Z), member image data (including an image URL and attribution), member term data (including the member type - Senator, congress served - 117, state represented - Vermont, party information - Democratic, term start year - 2021, and term end year), party data (e.g. Democratic), state data (e.g. Vermont), official website URL (e.g. <https://www.leahy.senate.gov/>), name information (e.g. Leahy, Patrick J.), office address (e.g. 437 Russell Senate Office Building Washington, DC 20510) and contact information (e.g. (202) 224-4242).
+
 ### Levels
-Depending on the data available, each member item in the API may contain a referrer URL to the sponsored legislation and cosponsored legislation. These levels contain more information on legislation sponsored and cosponsored by the member. Bill items in the deeper levels contain: an introduced date (e.g. 2022-06-16), bill type (e.g. S), congress (e.g. 117), title (e.g. Patent Trial and Appeal Board Reform Act of 2022), bill number (e.g. 4417), policy area (e.g. Commerce), latest action (e.g. Read twice and referred to the Committee on the Judiciary.), and a URL to the bill item in the API (e.g. https://api.congress.gov/v3/bill/117/s/4417). 
+
+Depending on the data available, each member item in the API may contain a referrer URL to the sponsored legislation and cosponsored legislation. These levels contain more information on legislation sponsored and cosponsored by the member. Bill items in the deeper levels contain: an introduced date (e.g. 2022-06-16), bill type (e.g. S), congress (e.g. 117), title (e.g. Patent Trial and Appeal Board Reform Act of 2022), bill number (e.g. 4417), policy area (e.g. Commerce), latest action (e.g. Read twice and referred to the Committee on the Judiciary.), and a URL to the bill item in the API (e.g. <https://api.congress.gov/v3/bill/117/s/4417>).
+
 ## committee
+
 ### Coverage
+
 Coverage information for committee data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more committee data at [About Committees and Committee Materials](https://www.congress.gov/help/committee-materials). View expanded documentation for the committee endpoints at [CommitteeEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
+
 ### Base Request
-The base request for committee data in the API is https://api.congress.gov/v3/committee. The request will return 20 results by default. Basic information about each committee item will be included in the response. Included in that basic information is the committee's system code (e.g. hsag00), name (e.g. Agriculture Committee), a URL to the committee item in the API (e.g. https://api.congress.gov/v3/committee/house/hsag00), chamber (e.g. House), committee type (e.g. Standing), and subcommittee information (including subcommittee system codes, names, and URLs to the subcommittee items in the API). Filters can be added to the URL in order to limit results returned to committees in a certain chamber (e.g. https://api.congress.gov/v3/committee/senate).
+
+The base request for committee data in the API is <https://api.congress.gov/v3/committee>. The request will return 20 results by default. Basic information about each committee item will be included in the response. Included in that basic information is the committee's system code (e.g. hsag00), name (e.g. Agriculture Committee), a URL to the committee item in the API (e.g. <https://api.congress.gov/v3/committee/house/hsag00>), chamber (e.g. House), committee type (e.g. Standing), and subcommittee information (including subcommittee system codes, names, and URLs to the subcommittee items in the API). Filters can be added to the URL in order to limit results returned to committees in a certain chamber (e.g. <https://api.congress.gov/v3/committee/senate>).
+
 ### Item
-Depending on the data available, each committee item in the API may contain the following: the committee's system code (e.g. hsag00), parent committee information (if a subcommittee), an update date in Congress.gov (e.g. 2019-10-03T18:19:10Z), a true/false flag for current committee status (e.g. True), subcommittee information (including subcommittee system codes, names, and URLs to the subcommittee items in the API), report count (e.g. 617), bill count (e.g. 16170), name history information (if the committee changed names over time), and committee type (e.g. Standing). 
+
+Depending on the data available, each committee item in the API may contain the following: the committee's system code (e.g. hsag00), parent committee information (if a subcommittee), an update date in Congress.gov (e.g. 2019-10-03T18:19:10Z), a true/false flag for current committee status (e.g. True), subcommittee information (including subcommittee system codes, names, and URLs to the subcommittee items in the API), report count (e.g. 617), bill count (e.g. 16170), name history information (if the committee changed names over time), and committee type (e.g. Standing).
+
 ## Levels
+
 Depending on the data available, each committee item in the API may contain a referrer URL to the following deeper levels: reports, bills, nominations, and Senate communications. These levels contain information on committee reports, legislation, nominations, and Senate communications associated with the committee. For example, the bills level contains the following for associated legislation to the committee: congress (e.g. 112), bill type (e.g. HR), bill number (e.g. 3914), relationship type to the committee (e.g. Referred to), the date of action (e.g. 2012-02-07T15:05:25Z), an update date in Congress.gov (e.g. 2019-02-17T21:05:21Z), and the count of legislation associated to the committee (e.g. 16170).
+
 ## nomination
+
 ### Coverage
+
 Coverage information for nominations data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more nominations data at [About Nominations by the U.S. President](https://www.congress.gov/help/nominations). View expanded documentation for the nomination endpoints at [NominationEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/NominationEndpoint.md).
+
 ### Base Request
-The base request for nominations data in the API is https://api.congress.gov/v3/nomination. The request will return 20 results by default. Basic information about each nomination item will be included in the response. Included in that basic information is the congress (e.g. 117), nomination number (e.g. 1783), partition number (e.g. 00), citation (e.g. PN1783), description (e.g. Ketanji Brown Jackson, of the District of Columbia, to be an Associate Justice of the Supreme Court of the United States, vice Stephen G. Breyer, retiring.), received date (e.g. 2022-02-28), the type of nomination (e.g. Civilian) and the organization (e.g. Supreme Court of the United States), an update date in Congress.gov (e.g. 2022-04-06 13:03:52+00:00), the latest action on the nomination (e.g. Confirmed by the Senate by Yea-Nay Vote. 53 - 47. Record Vote Number: 134.), a URL to the item in the API (e.g. https://api.congress.gov/v3/nomination/117/1783), and the organization (e.g. Supreme Court of the United States). Filters can be added to the URL in order to limit results returned to nominations in a single congress (e.g. https://api.congress.gov/v3/nomination/117).
+
+The base request for nominations data in the API is <https://api.congress.gov/v3/nomination>. The request will return 20 results by default. Basic information about each nomination item will be included in the response. Included in that basic information is the congress (e.g. 117), nomination number (e.g. 1783), partition number (e.g. 00), citation (e.g. PN1783), description (e.g. Ketanji Brown Jackson, of the District of Columbia, to be an Associate Justice of the Supreme Court of the United States, vice Stephen G. Breyer, retiring.), received date (e.g. 2022-02-28), the type of nomination (e.g. Civilian) and the organization (e.g. Supreme Court of the United States), an update date in Congress.gov (e.g. 2022-04-06 13:03:52+00:00), the latest action on the nomination (e.g. Confirmed by the Senate by Yea-Nay Vote. 53 - 47. Record Vote Number: 134.), a URL to the item in the API (e.g. <https://api.congress.gov/v3/nomination/117/1783>), and the organization (e.g. Supreme Court of the United States). Filters can be added to the URL in order to limit results returned to nominations in a single congress (e.g. <https://api.congress.gov/v3/nomination/117>).
+
 ### Item
+
 Depending on the data available, each nomination item in the API may contain the following: the nomination's congress (e.g. 117), nomination number (e.g. 1783), partition number (e.g. 00), citation (e.g. PN1783), executive calendar information, authority date, the received date (e.g. 2022-02-28), the description (e.g. Ketanji Brown Jackson, of the District of Columbia, to be an Associate Justice of the Supreme Court of the United States, vice Stephen G. Breyer, retiring.), nominee position information (including the organization - e.g. Supreme Court of the United States, position title - e.g. Associate Justice of the Supreme Count of the United States, and count - e.g. 1), committee count (e.g. 1), latest action on the nomination (e.g. Confirmed by the Senate by Yea-Nay Vote. 53 - 47. Record Vote Number: 134.), actions count (e.g. 19), printed hearings count (e.g. 0), and the update date in Congress.gov (e.g. 2022-04-06T13:03:52Z).
+
 ### Levels
+
 Depending on the data available, each nomination item in the API may contain a referrer URL to the following deeper levels: nominees, committees, actions, and printed hearings. These levels contain information on the nomination's nominees, associated committees, actions on the nominations, and associated printed hearings. For example, the actions level may contain the following for each action on the nomination: date of action (e.g. 2022-04-07), text of the action (e.g. Confirmed by the Senate by Yea-Nay Vote. 53 - 47. Record Vote Number: 134.), the type of action (e.g. Floor), Senate action code (e.g. S051310), and associated committee information.
+
 ## treaty
+
 ### Coverage
+
 Coverage information for treaty data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more about treaty data at [About Treaty Documents](https://www.congress.gov/help/treaty-documents). View expanded documentation for the treaty endpoints at [TreatyEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/TreatyEndpoint.md).
+
 ### Base Request
-The base request for treaty data in the API is https://api.congress.gov/v3/treaty. The request will return 20 results by default. Basic information about each treaty item will be included in the response. Included in that basic information is the congress during which the treaty was submitted (e.g. 116), treaty document number (e.g. 1), the congress during which the treaty was ratified (e.g. 116), the treaty suffix, the date the treaty document was transmitted to the Senate (e.g. 2019-04-29T00:00:00Z), the resolution of ratification text (note that the text is encased in CDATA), treaty subjects (e.g. International Law and Organization), any treaty parts, an update date in Congress.gov (e.g. 2022-07-12T16:01:15Z), and a URL to the item in the API (e.g. https://api.congress.gov/v3/treaty/116/1). Filters can be added to the URL in order to limit results returned to treaties submitted in single congress (e.g. https://api.congress.gov/v3/treaty/116).
+
+The base request for treaty data in the API is <https://api.congress.gov/v3/treaty>. The request will return 20 results by default. Basic information about each treaty item will be included in the response. Included in that basic information is the congress during which the treaty was submitted (e.g. 116), treaty document number (e.g. 1), the congress during which the treaty was ratified (e.g. 116), the treaty suffix, the date the treaty document was transmitted to the Senate (e.g. 2019-04-29T00:00:00Z), the resolution of ratification text (note that the text is encased in CDATA), treaty subjects (e.g. International Law and Organization), any treaty parts, an update date in Congress.gov (e.g. 2022-07-12T16:01:15Z), and a URL to the item in the API (e.g. <https://api.congress.gov/v3/treaty/116/1>). Filters can be added to the URL in order to limit results returned to treaties submitted in single congress (e.g. <https://api.congress.gov/v3/treaty/116>).
+
 ### Item
-Depending on the data available, each treaty item in the API may contain the following: the congress during which the treaty was submitted (e.g. 116), treaty document number (e.g. 1), the congress during which the treaty was ratified (e.g. 116), the treaty suffix, the former treaty number, the date the treaty document was transmitted to the Senate (e.g. 2019-04-29T00:00:00Z), the date the treaty became in force, related documents to the treaty and a URL to that item in the API (e.g. Ex. Rept. 116-5, https://api.congress.gov/v3/committeeReport/116/ERPT/5), the resolution of ratification text (the text is encased in CDATA), treaty subjects (e.g. International Law and Organization), any treaty parts, an update date in Congress.gov (e.g. 2022-07-12T16:01:15Z), and an actions count (e.g. 18).
+
+Depending on the data available, each treaty item in the API may contain the following: the congress during which the treaty was submitted (e.g. 116), treaty document number (e.g. 1), the congress during which the treaty was ratified (e.g. 116), the treaty suffix, the former treaty number, the date the treaty document was transmitted to the Senate (e.g. 2019-04-29T00:00:00Z), the date the treaty became in force, related documents to the treaty and a URL to that item in the API (e.g. Ex. Rept. 116-5, <https://api.congress.gov/v3/committeeReport/116/ERPT/5>), the resolution of ratification text (the text is encased in CDATA), treaty subjects (e.g. International Law and Organization), any treaty parts, an update date in Congress.gov (e.g. 2022-07-12T16:01:15Z), and an actions count (e.g. 18).
+
 ### Levels
+
 Depending on the data available, each treaty item in the API may contain a referrer URL to the actions deeper level. The actions level may contain the following for each action on the treaty: date of action (e.g. 2019-10-17), Senate action code (e.g. S05235), text of the action (e.g. Cloture motion presented in Senate.), the type of action (e.g. Floor), and associated committee information.
+
 ## committee-report
+
 ### Coverage
+
 Coverage information for committee report data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more about committee report data at [About Committee Reports of the U.S. Congress](https://www.congress.gov/help/committee-reports). View expanded documentation for the committee report endpoints at [CommitteeReportEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeReportEndpoint.md).
+
 ### Base Request
-The base request for committee report data in the API is https://api.congress.gov/v3/committee-report. The request will return 20 results by default. Basic information about each committee report item will be included in the response. Included in that basic information is the committee report citation (e.g. H. Rept. 117-403), a URL to the item in the API (e.g. https://api.congress.gov/v3/committee-report/117/HRPT/403), an update date in Congress.gov (e.g. 2022-07-06 23:56:19+00:00), the congress (e.g. 117), the chamber (e.g. House), the report type (e.g. HRPT), the report number (e.g. 351), and the part (e.g. 1). Filters can be added to the URL in order to limit results returned to committee reports in a single congress (e.g. https://api.congress.gov/v3/committee-report/117) or congress and report type (e.g. https://api.congress.gov/v3/committee-report/117/HRPT).
+
+The base request for committee report data in the API is <https://api.congress.gov/v3/committee-report>. The request will return 20 results by default. Basic information about each committee report item will be included in the response. Included in that basic information is the committee report citation (e.g. H. Rept. 117-403), a URL to the item in the API (e.g. <https://api.congress.gov/v3/committee-report/117/HRPT/403>), an update date in Congress.gov (e.g. 2022-07-06 23:56:19+00:00), the congress (e.g. 117), the chamber (e.g. House), the report type (e.g. HRPT), the report number (e.g. 351), and the part (e.g. 1). Filters can be added to the URL in order to limit results returned to committee reports in a single congress (e.g. <https://api.congress.gov/v3/committee-report/117>) or congress and report type (e.g. <https://api.congress.gov/v3/committee-report/117/HRPT>).
+
 ### Item
-Depending on the data available, each committee report item in the API may contain the following: the congress during which the committee report was published (e.g. 117), the chamber (e.g. House), the session of congress (e.g. 2), the citation (e.g. H. Rept. 117-403), the report number (e.g. 403), the part number (e.g. 1), the report type (e.g. HRPT), an update date in Congress.gov (e.g. 2022-07-06T23:56:19Z), a true/false flag if the report is a conference report[^10] (e.g. False), the title of the report (e.g. DEPARTMENTS OF LABOR, HEALTH AND HUMAN SERVICES, AND EDUCATION, AND RELATED AGENCIES APPROPRIATIONS BILL, 2023), the date of issue (e.g. 2022-07-05T04:00:00Z), associated committee information (e.g. Appropriations Committee) including a URL to the committee item in the API (e.g. https://api.congress.gov/v3/committee/house/hsap00), and a text count (e.g. 2). 
+
+Depending on the data available, each committee report item in the API may contain the following: the congress during which the committee report was published (e.g. 117), the chamber (e.g. House), the session of congress (e.g. 2), the citation (e.g. H. Rept. 117-403), the report number (e.g. 403), the part number (e.g. 1), the report type (e.g. HRPT), an update date in Congress.gov (e.g. 2022-07-06T23:56:19Z), a true/false flag if the report is a conference report[^10] (e.g. False), the title of the report (e.g. DEPARTMENTS OF LABOR, HEALTH AND HUMAN SERVICES, AND EDUCATION, AND RELATED AGENCIES APPROPRIATIONS BILL, 2023), the date of issue (e.g. 2022-07-05T04:00:00Z), associated committee information (e.g. Appropriations Committee) including a URL to the committee item in the API (e.g. <https://api.congress.gov/v3/committee/house/hsap00>), and a text count (e.g. 2).
+
 ### Levels
+
 Depending on the data available, each committee report item in the API may contain a referrer URL to the text deeper level. The text level may contain the following: a URL for the text in Congress.gov (e.g. www.congress.gov/117/crpt/hrpt403/CRPT-117hrpt403.pdf), the type of format (e.g. PDF), and whether the text is errata (e.g. Y/N).
+
 ## congressional-record
+
 ### Coverage
+
 Coverage information for Congressional Record data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Note that while the Bound Congressional Record is available in Congress.gov, it is not yet available in the API. Read more about Congressional Record data at [About the Congressional Record](https://www.congress.gov/help/congressional-record). View expanded documentation for the congressional record endpoint at [CongressionalRecordEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CongressionalRecordEndpoint.md).
+
 ### Base Request
-The base request for Congressional Record data in the API is https://api.congress.gov/v3/congressional-record. The request will return 20 results by default. Basic information about each Congressional Record issue are included in the response. Included in that basic information is the issue's congress (e.g. 117), the issue number (e.g. 114), the issue's publish date (e.g. 2022-07-12), the session of congress (e.g. 2), the volume number (e.g. 168), and URLs for the issue's sections and the entire issue in PDF format (e.g. Daily Digest, https://www.congress.gov/117/crec/2022/07/12/168/114/CREC-2022-07-12-dailydigest.pdf).
+
+The base request for Congressional Record data in the API is <https://api.congress.gov/v3/congressional-record>. The request will return 20 results by default. Basic information about each Congressional Record issue are included in the response. Included in that basic information is the issue's congress (e.g. 117), the issue number (e.g. 114), the issue's publish date (e.g. 2022-07-12), the session of congress (e.g. 2), the volume number (e.g. 168), and URLs for the issue's sections and the entire issue in PDF format (e.g. Daily Digest, <https://www.congress.gov/117/crec/2022/07/12/168/114/CREC-2022-07-12-dailydigest.pdf>).
+
 ## house-communication
+
 ### Coverage
+
 Coverage information for House communications data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates) on Congress.gov. Read more about House communications data at [About Communications to the House](https://www.congress.gov/help/house-communications). View expanded documentation for the House communication endpoints at [HouseCommunicationEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/HouseCommunicationEndpoint.md).
+
 ### Base Request
-The base request for House communications data in the API is https://api.congress.gov/v3/house-communication. The request will return 20 results by default. Basic information about each House communication item will be included in the response. Included in that basic information is the chamber (e.g. House), communication number (e.g. 3273), type of communication (e.g. Executive Communication), congress (e.g. 117), and a URL to the item in the API (e.g. https://api.congress.gov/v3/house-communication/117/ec/3273). Filters can be added to the URL in order to limit results returned to House Communications in a single congress (e.g. https://api.congress.gov/v3/house-communication/117) or congress and communication type (e.g. https://api.congress.gov/v3/house-communication/117/ec).
+
+The base request for House communications data in the API is <https://api.congress.gov/v3/house-communication>. The request will return 20 results by default. Basic information about each House communication item will be included in the response. Included in that basic information is the chamber (e.g. House), communication number (e.g. 3273), type of communication (e.g. Executive Communication), congress (e.g. 117), and a URL to the item in the API (e.g. <https://api.congress.gov/v3/house-communication/117/ec/3273>). Filters can be added to the URL in order to limit results returned to House Communications in a single congress (e.g. <https://api.congress.gov/v3/house-communication/117>) or congress and communication type (e.g. <https://api.congress.gov/v3/house-communication/117/ec>).
+
 ### Item
+
 Depending on the data available, each House communication item in the API may contain the following: the chamber (e.g. House), communication number (e.g. 3273), type of communication (e.g. Executive Communication), congress (e.g. 117), the abstract (e.g. A letter from the Secretary, Department of Defense, transmitting a letter stating the Department is honored to, and will, provide military funeral support for former Senator Robert J. Dole; to the Committee on Armed Services.), the date the communication was published in the Congressional Record (e.g. 2022-01-28), and associated committee information (e.g. Armed Services Committee) including the date the communication was referred to committee (e.g. 2022-01-28).
+
 ## house-requirement
+
 ### Coverage
+
 Coverage information for House requirements data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about House requirements data within [About Communications to the House](https://www.congress.gov/help/house-communications) on Congress.gov. View expanded documentation for the House requirement endpoints at [HouseRequirementEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/HouseRequirementEndpoint.md).
+
 ### Base Request
-The base request for House requirements data in the API is https://api.congress.gov/v3/house-requirement. The request will return 20 results by default. Basic information about each House requirement item will be included in the response. Included in that basic information is the requirement number (e.g. 12478), an update date in Congress.gov (e.g. 2021-11-05), and a URL to the item in the API (e.g. https://api.congress.gov/v3/house-requirement/12478). 
+
+The base request for House requirements data in the API is <https://api.congress.gov/v3/house-requirement>. The request will return 20 results by default. Basic information about each House requirement item will be included in the response. Included in that basic information is the requirement number (e.g. 12478), an update date in Congress.gov (e.g. 2021-11-05), and a URL to the item in the API (e.g. <https://api.congress.gov/v3/house-requirement/12478>).
+
 ### Item
+
 Depending on the data available, each House requirement item in the API may contain the following:  the requirement number (e.g. 12478), an update date in Congress.gov (e.g. 2021-11-05), an agency or government entity associated with the report (e.g. Executive Office of the President), the frequency upon which the report must be submitted (e.g. If specified circumstances arise.), the nature of the report (e.g. Approval of recommendations related to reducing the costs of federal real estate.), and an associated statute citation (e.g. Public Law 114–287, section 13(c)(1); (130 Stat. 1471)).
+
 ## senate-communication
+
 ### Coverage
+
 Coverage information for Senate communications data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about Senate communications data at [About Senate Executive and Other Communications](https://www.congress.gov/help/senate-communications) on Congress.gov. View expanded documentation for the Senate communication endpoints at [SenateCommunicationEndpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/SenateCommunicationEndpoint.md).
+
 ### Base Request
-The base request for Senate communications data in the API is https://api.congress.gov/v3/senate-communication. The request will return 20 results by default. Basic information about each Senate communication item will be included in the response. Included in that basic information is the chamber (e.g. Senate), communication number (e.g. 2561), type of communication (e.g. Executive Communication), congress (e.g. 117), and a URL to the item in the API (e.g. https://api.congress.gov/v3/senate-communication/117/ec/2561). Filters can be added to the URL in order to limit results returned to Senate Communications in a single congress (e.g. https://api.congress.gov/v3/senate-communication/117) or congress and communication type (e.g. https://api.congress.gov/v3/senate-communication/117/ec).
+
+The base request for Senate communications data in the API is <https://api.congress.gov/v3/senate-communication>. The request will return 20 results by default. Basic information about each Senate communication item will be included in the response. Included in that basic information is the chamber (e.g. Senate), communication number (e.g. 2561), type of communication (e.g. Executive Communication), congress (e.g. 117), and a URL to the item in the API (e.g. <https://api.congress.gov/v3/senate-communication/117/ec/2561>). Filters can be added to the URL in order to limit results returned to Senate Communications in a single congress (e.g. <https://api.congress.gov/v3/senate-communication/117>) or congress and communication type (e.g. <https://api.congress.gov/v3/senate-communication/117/ec>).
+
 ### Item
-Depending on the data available, each Senate communication item in the API may contain the following: the chamber (e.g. Senate), communication number (e.g. 2561), type of communication (e.g. Executive Communication), congress (e.g. 117), the abstract (e.g. A communication from the Board Chairman and Chief Executive Officer, Farm Credit Administration, transmitting, pursuant to law, the Administration's annual report for calendar year 2021; to the Committee on Agriculture, Nutrition, and Forestry.), the date the communication was published in the Congressional Record (e.g. 2021-11-03), and associated committee information (e.g. Agriculture, Nutrition, and Forestry Committee) including the date the communication was referred to committee (e.g. 2021-11-03) and a URL to the committee item in the API (e.g. https://api.congress.gov/v3/committee/senate/ssaf00).
+
+Depending on the data available, each Senate communication item in the API may contain the following: the chamber (e.g. Senate), communication number (e.g. 2561), type of communication (e.g. Executive Communication), congress (e.g. 117), the abstract (e.g. A communication from the Board Chairman and Chief Executive Officer, Farm Credit Administration, transmitting, pursuant to law, the Administration's annual report for calendar year 2021; to the Committee on Agriculture, Nutrition, and Forestry.), the date the communication was published in the Congressional Record (e.g. 2021-11-03), and associated committee information (e.g. Agriculture, Nutrition, and Forestry Committee) including the date the communication was referred to committee (e.g. 2021-11-03) and a URL to the committee item in the API (e.g. <https://api.congress.gov/v3/committee/senate/ssaf00>).
 
 [^1]: Read more about [titles](https://www.congress.gov/help/legislative-glossary#glossary_title) on Congress.gov.
 [^2]: Read more [About Committee Reports](https://www.congress.gov/help/committee-reports) on Congress.gov. Click [here](#committeereport) to review brief documentation about the committee reports endpoints.

--- a/Documentation/CommitteeEndpoint.md
+++ b/Documentation/CommitteeEndpoint.md
@@ -1,262 +1,283 @@
 # Committee endpoint
+
 ## Coverage
+
 Coverage information for committee data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about committee data at [About Committees and Committee Materials](https://www.congress.gov/help/committee-materials) and committee name data at [Committee Name History](https://www.congress.gov/help/committee-name-history) on Congress.gov.
+
 ## OpenAPI Specification
-View OpenAPI Specification on the committee API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/committee/committee_list). 
+
+View OpenAPI Specification on the committee API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/committee/committee_list).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
-Note that committee items at the list level can be filtered down by congress (e.g. 117) and by chamber (e.g. House) – https://api.congress.gov/v3/committee/117/house?api_key=).
+
+Note that committee items at the list level can be filtered down by congress (e.g. 117) and by chamber (e.g. House) – <https://api.congress.gov/v3/committee/117/house?api_key=>).
 
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<committees>`
 
  Parent container for committees and subcommittees. A `<committees>` element may contain the following children:
- - `<item>`
-   - Container for an individual committee or subcommittee. An `<item>` element is repeatable and may contain the following children: 
-     - `<url>` (e.g., https://api.congress.gov/v3/committee/house/hspw00)
-       - A referrer URL to the committee or subcommittee item in the API.     
-     - `<systemCode>` (e.g., hspw00)
-        -	Unique ID value for the committee or subcommittee. The first letter represents the chamber, i.e., House, Senate, or Joint. The two numerals at the end of the `<systemCode>` indicate whether the entity is a full committee or subcommittee. Full committees are represented by a double zero and subcommittees will have an identical systemCode as its parent committee but with numerals other than the double zero.  
-     - `<name>` (e.g., Transportation and Infrastructure Committee)
-        -	The name of the committee or subcommittee.
-     - `<parent>`
-       - Container for parent committee information providing an indication of whether the subcommittee has a parent. A `<parent>` element may contain the following children:
-       		- `<url>`
-         		- A referrer URL to the parent committee item in the API.
-       		- `<systemCode>`
-         		- Unique ID value for the parent committee. Parent committee `<systemCode>` values end in a double zero.      
-       		- `<name>`
-         		- The name of the parent committee.
-     - `<subcommittees>`
-       - Container for subcommittee information and indication of whether a parent committee has subcommittees. A `<subcommittees>` element is repeatable and may contain the following children: 
-       		- `<item>`
-         		- Container for an individual subcommittee of the committee. An `<item>` element is repeatable and may contain the following children:
-        			 - `<url>` (e.g., https://api.congress.gov/v3/committee/house/hspw14)
-        			 	- A referrer URL to the subcommittee item in the API. 
-         			- `<systemCode>` (e.g., hspw14)
-           				-  The unique ID value for the subcommittee. Subcommittee `<systemCode>` values contain numerals other than a double zero. 
-         			- `<name>` (e.g., Railroads, Pipelines, and Hazardous Materials Subcommittee)
-           				- The name of the subcommittee.
-     - `<chamber>` (e.g., House)
-       -  The committee's chamber of origin.
-       -  Possible values are "House", "Senate", and "Joint".
-     - `<committeeTypeCode>` (e.g., Standing)
-       - The type of committee.
-       - Possible values are "Commission or Caucus", "Joint", "Other", "Select", "Special", "Standing", "Subcommittee", and "Task Force".
+
+- `<item>`
+  - Container for an individual committee or subcommittee. An `<item>` element is repeatable and may contain the following children:
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hspw00>)
+      - A referrer URL to the committee or subcommittee item in the API.
+    - `<systemCode>` (e.g., hspw00)
+      - Unique ID value for the committee or subcommittee. The first letter represents the chamber, i.e., House, Senate, or Joint. The two numerals at the end of the `<systemCode>` indicate whether the entity is a full committee or subcommittee. Full committees are represented by a double zero and subcommittees will have an identical systemCode as its parent committee but with numerals other than the double zero.  
+    - `<name>` (e.g., Transportation and Infrastructure Committee)
+      - The name of the committee or subcommittee.
+    - `<parent>`
+      - Container for parent committee information providing an indication of whether the subcommittee has a parent. A `<parent>` element may contain the following children:
+        - `<url>`
+          - A referrer URL to the parent committee item in the API.
+        - `<systemCode>`
+          - Unique ID value for the parent committee. Parent committee `<systemCode>` values end in a double zero.
+        - `<name>`
+          - The name of the parent committee.
+    - `<subcommittees>`
+      - Container for subcommittee information and indication of whether a parent committee has subcommittees. A `<subcommittees>` element is repeatable and may contain the following children:
+        - `<item>`
+          - Container for an individual subcommittee of the committee. An `<item>` element is repeatable and may contain the following children:
+            - `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hspw14>)
+              - A referrer URL to the subcommittee item in the API.
+            - `<systemCode>` (e.g., hspw14)
+              - The unique ID value for the subcommittee. Subcommittee `<systemCode>` values contain numerals other than a double zero.
+            - `<name>` (e.g., Railroads, Pipelines, and Hazardous Materials Subcommittee)
+              - The name of the subcommittee.
+    - `<chamber>` (e.g., House)
+      - The committee's chamber of origin.
+      - Possible values are "House", "Senate", and "Joint".
+    - `<committeeTypeCode>` (e.g., Standing)
+      - The type of committee. Possible values are "Commission or Caucus", "Joint", "Other", "Select", "Special", "Standing", "Subcommittee", and "Task Force".
+
 ### Item Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<committee>`
 
 Parent container for an individual committee or subcommittee entry. A `<committee>` element may contain the following children:
+
 - `<systemCode>` (e.g., hspw00)
   - The unique ID value for the committee. Parent committee `<systemCode>` values end in a double zero while those for a subcommittee end with numerals other than a double zero.
- - `<parent>`  
- 	- Container for parent committee information providing an indication of whether the subcommittee has a parent. A `<parent>` element may contain the following children:
-      - `<url>`
-        - A referrer URL to the committee's parent in the API.
-      - `<systemCode>`
-		- The unique ID of the committee's parent. Parent committee `<systemCode>` values end in a double zero. 
-      - `<name>`
-      	- The name of the committee's parent.  
-  - `<updateDate>` (e.g., 2020-02-04T00:07:37Z)
-     - The date of update in Congress.gov.
-  - `<isCurrent>` (e.g., True)
-  	- Flag indicating whether the committee is currently active.
-  	- Possible values are "True" or "False". 
-  - `<subcommittees>`
-      - Container for all of the committee's subcommittee's. The `<subcommittee>` element may contain the following children, which are repeatable:  
-      	- `<item>`
-       	 	- Container for an individual subcommittee under the committee. The `<item>` element is repeatable and may contain the following children:
-         		- `<url>` (e.g., https://api.congress.gov/v3/committee/house/hspw14)
-           			- A referrer URL to the subcommittee item in the API.
-        		- `<systemCode>` (e.g., hspw14)
-          			- The unique ID of the subcommittee. Subcommittee `<systemCode>` values contain numerals other than a double zero.   
-        		- `<name>` (e.g., Railroads, Pipelines, and Hazardous Materials Subcommittee)
-          			- The name of the subcommittee. 
+- `<parent>`  
+  - Container for parent committee information providing an indication of whether the subcommittee has a parent. A `<parent>` element may contain the following children:
+    - `<url>`
+      - A referrer URL to the committee's parent in the API.
+    - `<systemCode>`
+      - The unique ID of the committee's parent. Parent committee `<systemCode>` values end in a double zero.
+    - `<name>`
+      - The name of the committee's parent.  
+- `<updateDate>` (e.g., 2020-02-04T00:07:37Z)
+  - The date of update in Congress.gov.
+- `<isCurrent>` (e.g., True)
+  - Flag indicating whether the committee is currently active.
+  - Possible values are "True" or "False".
+- `<subcommittees>`
+  - Container for all of the committee's subcommittee's. The `<subcommittee>` element may contain the following children, which are repeatable:  
+    - `<item>`
+      - Container for an individual subcommittee under the committee. The `<item>` element is repeatable and may contain the following children:
+      - `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hspw14>)
+        - A referrer URL to the subcommittee item in the API.
+      - `<systemCode>` (e.g., hspw14)
+        - The unique ID of the subcommittee. Subcommittee `<systemCode>` values contain numerals other than a double zero.
+      - `<name>` (e.g., Railroads, Pipelines, and Hazardous Materials Subcommittee)
+        - The name of the subcommittee.
 - `<reports>`
-     - Container for committee reports issued by a committee. A `<reports>` element may contain the following children: 
-        - `<url>` (e.g., https://api.congress.gov/v3/committee/house/hspw00/reports)
-        	- A referrer URL to the committee reports level of the committee API. Click [here](#committee-reports-level) for more information about the committee reports level.
-        - `<count>` (e.g., 1373)
-          - The number of reports present in the committee's reports API endpoint.  
-- `<communications>` 
-	- Container for Senate communications associated with a committee. A `<communications>` element may contain the following children (the below data is taken from https://api.congress.gov/v3/committee/senate/ssas00):
-		- `<url>` (e.g., https://api.congress.gov/v3/committee/senate/ssas00/senate-communication)
-			- A referrer URL to the Senate communications level of the committee API. Click [here](#senate-communications-level) for more information about the Senate communications level. 
-		- `<count>` (e.g., 11117)
-			- The number of Senate communications in the committee's Senate communications API endpoint.  
+  - Container for committee reports issued by a committee. A `<reports>` element may contain the following children:
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hspw00/reports>)
+      - A referrer URL to the committee reports level of the committee API. Click [here](#committee-reports-level) for more information about the committee reports level.
+    - `<count>` (e.g., 1373)
+      - The number of reports present in the committee's reports API endpoint.  
+- `<communications>`
+  - Container for Senate communications associated with a committee. A `<communications>` element may contain the following children (the below data is taken from <https://api.congress.gov/v3/committee/senate/ssas00>):
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee/senate/ssas00/senate-communication>)
+      - A referrer URL to the Senate communications level of the committee API. Click [here](#senate-communications-level) for more information about the Senate communications level.
+    - `<count>` (e.g., 11117)
+      - The number of Senate communications in the committee's Senate communications API endpoint.  
 - `<bills>`
-	- Container for bills associated with a committee. A `<bills>` element may contain the following children:
-		- `<url>` (e.g., https://api.congress.gov/v3/committee/house/hspw00/bills)
-			- A referrer URL to the bills level of the committee API. Click [here](#bills-level) for more information about the bills level. 
-		- `<count>` (e.g., 25313)
-			- The number of bills in the committee's bills API endpoint.  
+  - Container for bills associated with a committee. A `<bills>` element may contain the following children:
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hspw00/bills>)
+      - A referrer URL to the bills level of the committee API. Click [here](#bills-level) for more information about the bills level.
+    - `<count>` (e.g., 25313)
+      - The number of bills in the committee's bills API endpoint.  
 - `<nominations>`
-	- Container for nominations associated with a committee. This is exclusive to the Senate. A `<nominations>` element may contain the following children (the below data is taken from https://api.congress.gov/v3/committee/senate/ssas00):
-		- `<url>` (e.g., https://api.congress.gov/v3/committee/senate/ssas00/nominations)
-			- A referrer URL to the nominations level of the committee API. Click [here](#nominations-level) for more information about the nominations level. 
-		- `<count>` (e.g., 20126)
-			- The number of nominations in the committee's nominations API endpoint. 
+  - Container for nominations associated with a committee. This is exclusive to the Senate. A `<nominations>` element may contain the following children (the below data is taken from <https://api.congress.gov/v3/committee/senate/ssas00>):
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee/senate/ssas00/nominations>)
+      - A referrer URL to the nominations level of the committee API. Click [here](#nominations-level) for more information about the nominations level.
+    - `<count>` (e.g., 20126)
+      - The number of nominations in the committee's nominations API endpoint.
 - `<history>`
-	- Container for the committee's activity/identification history across Congresses. The `<history>` element may contain the following children, which are repeatable:  
-		- `<item>`
-			- Container for a committee's activity/identification. The `<item>` element is repeatable and may contain the following children:
-				- `<endDate>`
-					- The date the committee, as named, ceased to exist. 
-				- `<officialName>` (e.g., Committee on Transportation and Infrastructure)
-					- The full official name of the committee.  
-				- `<libraryOfCongressName>` (e.g., Transportation and Infrastructure)
-					- The shortened name of the committee. 
-				- `<startDate>` (e.g., 1995-01-04T05:00:00Z)
-					- The date the committee, as named, was formed. 
-				- `<committeeTypeCode>`
-					- The type of committee.
-					- Possible values are "Commission or Caucus", "Joint", "Other", "Select", "Special", "Standing", "Subcommittee", and "Task Force".
-				- `<establishingAuthority>`
-					- The legislative authority for the committee. 
-				- `<locLinkedDataId>`
-					- ID value to support linking with Library of Congress data. NOTE: Not currently in use.
-				- `<superintendentDocumentNumber>`
-					- ID value to support linking with GPO data. NOTE: Not currently in use. 
-				- `<naraId>`
-					- ID value to support linking with NARA data. NOTE: Not currently in use. 
+  - Container for the committee's activity/identification history across Congresses. The `<history>` element may contain the following children, which are repeatable:  
+    - `<item>`
+      - Container for a committee's activity/identification. The `<item>` element is repeatable and may contain the following children:
+        - `<endDate>`
+          - The date the committee, as named, ceased to exist.
+        - `<officialName>` (e.g., Committee on Transportation and Infrastructure)
+          - The full official name of the committee.  
+        - `<libraryOfCongressName>` (e.g., Transportation and Infrastructure)
+          - The shortened name of the committee.
+        - `<startDate>` (e.g., 1995-01-04T05:00:00Z)
+          - The date the committee, as named, was formed.
+        - `<committeeTypeCode>`
+          - The type of committee.
+          - Possible values are "Commission or Caucus", "Joint", "Other", "Select", "Special", "Standing", "Subcommittee", and "Task Force".
+        - `<establishingAuthority>`
+          - The legislative authority for the committee.
+        - `<locLinkedDataId>`
+          - ID value to support linking with Library of Congress data. NOTE: Not currently in use.
+        - `<superintendentDocumentNumber>`
+          - ID value to support linking with GPO data. NOTE: Not currently in use.
+        - `<naraId>`
+          - ID value to support linking with NARA data. NOTE: Not currently in use.
 - `<type>`  (e.g., Standing)
-  	- Type of committee. 
-  	- Possible values are "Commission or Caucus", "Joint", "Other", "Select", "Special", "Standing", "Subcommittee" and "Task Force".
+  - Type of committee.
+  - Possible values are "Commission or Caucus", "Joint", "Other", "Select", "Special", "Standing", "Subcommittee" and "Task Force".
+
 ### Committee Reports Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<reports>`
 
 Parent container for reports issued by a committee. The `<reports>` element may contain the following children, which are repeatable:
- - `<item>`
-   - Container for individual reports issued by the committee. The `<item>` container is repeatable and may contain the following children:
-   		- `<citation>` (e.g., H. Rept. 109-570)
-   			- The citation of the report issued by the committee.  
-   		- `<url>` (e.g., https://api.congress.gov/v3/committee-report/109/HRPT/570)
-   			- A referrer URL to the committee report item in the API. Documentation for the committee report endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeReportEndpoint.md). 
-   		- `<updateDate>` (e.g., 2021-07-10 16:19:06+00:00)
-   			- The date of update in Congress.gov. 
-   		- `<congress>` (e.g., 109)
-   		    - The congress during which the committee report was produced.
-   		- `<chamber>` (e.g., House)
-   		    - The chamber where the committee report was produced.
-   		    - Possible values are "House" and "Senate".
-   		- `<type>` (e.g., HRPT)
-   		    - The type of report.
-   		    - Possible values are "HRPT", "SRPT", and "ERPT".
-   		- `<number>` (e.g., 570)
-   		    - The assigned committee report number.
-   		- `<part>` (e.g., 1)
-   		    - The part number of the report.
-   		    - Committee reports without parts will have a value of 1. If there are multiple parts, the number value may be 2, 3, etc.
+
+- `<item>`
+  - Container for individual reports issued by the committee. The `<item>` container is repeatable and may contain the following children:
+    - `<citation>` (e.g., H. Rept. 109-570)
+      - The citation of the report issued by the committee.  
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee-report/109/HRPT/570>)
+      - A referrer URL to the committee report item in the API. Documentation for the committee report endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeReportEndpoint.md).
+    - `<updateDate>` (e.g., 2021-07-10 16:19:06+00:00)
+      - The date of update in Congress.gov.
+    - `<congress>` (e.g., 109)
+      - The congress during which the committee report was produced.
+    - `<chamber>` (e.g., House)
+      - The chamber where the committee report was produced.
+      - Possible values are "House" and "Senate".
+    - `<type>` (e.g., HRPT)
+      - The type of report.
+      - Possible values are "HRPT", "SRPT", and "ERPT".
+    - `<number>` (e.g., 570)
+      - The assigned committee report number.
+    - `<part>` (e.g., 1)
+      - The part number of the report.
+      - Committee reports without parts will have a value of 1. If there are multiple parts, the number value may be 2, 3, etc.
 
 ### Bills Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<committee-bills>`
 
 Parent container for bills and resolutions associated with the committee or subcommittee. The `<committee-bills>` element may contain the following children:
- - `<url>` (e.g., https://api.congress.gov/v3/committee/house/hspw00/bills)
-   - A referrer URL to the committee's bills level in the API.
- - `<count>` (e.g., 25313)
-   - The number of bills and resolutions in the bills level API. 
- - `<bills>`
-   - Container for all bills and resolutions associated with the committee. The `<bills>` element may contain the following children:
-   		- `<bill>`
-   			- Container for individual bills and resolutions associated with the committee. The `<bill>` element is repeatable and may contain the following children:
-   				- `<congress>` (e.g., 112)
-   					- The Congress during which the bill or resolution was introduced.  
-     			- `<billType>` (e.g., HCONRES)
-       				- The type of bill or resolution.
-       				- Possible values are “HR”, “S”, “HJRES”, “SJRES”, “HCONRES”, “SCONRES”, “HRES” or “SRES”. House committees will not have a bill type value of “SRES” and Senate committees will not have a bill type value of “HRES”.  	   
-     			- `<billNumber>` (e.g., 117)
-       				- The assigned bill or resolution number.  
-     			- `<relationshipType>` (e.g., Referred to)
-       				- The relationship of the bill or resolution to the committee. 
-     			- `<actionDate>` (e.g., 2012-04-19T13:01:00Z)
-       				-  The date the `<relationshipType>` occurred.
-    	 		- `<updateDate>` (e.g., 2019-02-17T21:10:13Z)
-       				- The date of update in Congress.gov. 
+
+- `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hspw00/bills>)
+  - A referrer URL to the committee's bills level in the API.
+- `<count>` (e.g., 25313)
+  - The number of bills and resolutions in the bills level API.
+- `<bills>`
+  - Container for all bills and resolutions associated with the committee. The `<bills>` element may contain the following children:
+    - `<bill>`
+      - Container for individual bills and resolutions associated with the committee. The `<bill>` element is repeatable and may contain the following children:
+    - `<congress>` (e.g., 112)
+      - The Congress during which the bill or resolution was introduced.  
+    - `<billType>` (e.g., HCONRES)
+      - The type of bill or resolution.
+      - Possible values are “HR”, “S”, “HJRES”, “SJRES”, “HCONRES”, “SCONRES”, “HRES” or “SRES”. House committees will not have a bill type value of “SRES” and Senate committees will not have a bill type value of “HRES”.
+    - `<billNumber>` (e.g., 117)
+      - The assigned bill or resolution number.  
+    - `<relationshipType>` (e.g., Referred to)
+      - The relationship of the bill or resolution to the committee.
+    - `<actionDate>` (e.g., 2012-04-19T13:01:00Z)
+      - The date the `<relationshipType>` occurred.
+    - `<updateDate>` (e.g., 2019-02-17T21:10:13Z)
+      - The date of update in Congress.gov.
+
 ### Nominations Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<nominations>`
 
-Parent container for nominations associated with a Senate committee (the below data is taken from https://api.congress.gov/v3/committee/senate/ssju00/nominations?api_key=). The `<nominations>` element may contain the following children, which are repeatable:
- - `<item>`
- 	- Container for individual nominations considered by the Senate committee. The `<item>` element is repeatable and may contain the following children: 
- 		- `<congress>` (e.g., 117)
- 			- The Congress during which the nomination was received.	  
- 		- `<number>` (e.g., 2439)
- 			- The assigned nomination number.
- 			- Read more about nomination numbering at [About Nominations by the U.S. President](https://www.congress.gov/help/nominations) on Congress.gov. 	  
- 		- `<partNumber>` (e.g., 00)
- 			- The part number for the individual nomination. Nominations with multiple nominees may be partitioned if the nominees follow different confirmation paths.
- 		- `<citation>` (e.g., PN2439)
- 			- The citation identifying the nomination. PN indicates "Presidential Nomination" and the digits are the nominations assigned number. If the nomination was partitioned, the citation will include a dash and the partition number (e.g. PN78-4).  
- 		- `<description>` (e.g., Araceli Martinez-Olguin, of California, to be United States District Judge for the Northern District of California, vice Jeffrey S. White, retired.)
- 			- The description of the nomination.
- 		- `<receivedDate>` (e.g., 2022-08-01)
- 			- The date the nomination was received from the President.
- 		- `<nominationType>`
-			- Container for nomination type data. A `<nominationType>` element may contain the following children:
-				- `<isCivilian>` (e.g., True)
-					- Flag indicating whether the nomination is for a civilian position. 
-					- Possible values are "True" or "False".
-				- `<inMilitary>` (e.g., False)
-					- Flag indicating whether the nomination is for a military position.
-					- Possible values are "True" or "False".
-		- `<updateDate>` (e.g., 2022-08-02 04:25:19+00:00)
-			- Date of update in Congress.gov
-		- `<latestAction>`
-			- Container for the latest action taken on the nomination. A `<latestAction>` element may contain the following children:
-				- `<actionDate>`(e.g., 2022-08-01)
-					- The date of the latest action on the nomination.
-				- `<text>` (e.g., Received in the Senate and referred to the Committee on the Judiciary.)
-					- The text of the latest action taken on the nomination. 
-				- `<url>` (e.g., https://api.congress.gov/v3/nomination/117/2439)
-					- A referrer URL to the nomination item in the API. Documentation for the nomination endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/NominationEndpoint.md).
+Parent container for nominations associated with a Senate committee (the below data is taken from <https://api.congress.gov/v3/committee/senate/ssju00/nominations?api_key>=). The `<nominations>` element may contain the following children, which are repeatable:
+
+- `<item>`
+  - Container for individual nominations considered by the Senate committee. The `<item>` element is repeatable and may contain the following children:
+    - `<congress>` (e.g., 117)
+      - The Congress during which the nomination was received.
+    - `<number>` (e.g., 2439)
+      - The assigned nomination number.
+      - Read more about nomination numbering at [About Nominations by the U.S. President](https://www.congress.gov/help/nominations) on Congress.gov.
+    - `<partNumber>` (e.g., 00)
+      - The part number for the individual nomination. Nominations with multiple nominees may be partitioned if the nominees follow different confirmation paths.
+    - `<citation>` (e.g., PN2439)
+      - The citation identifying the nomination. PN indicates "Presidential Nomination" and the digits are the nominations assigned number. If the nomination was partitioned, the citation will include a dash and the partition number (e.g. PN78-4).  
+    - `<description>` (e.g., Araceli Martinez-Olguin, of California, to be United States District Judge for the Northern District of California, vice Jeffrey S. White, retired.)
+      - The description of the nomination.
+    - `<receivedDate>` (e.g., 2022-08-01)
+      - The date the nomination was received from the President.
+    - `<nominationType>`
+      - Container for nomination type data. A `<nominationType>` element may contain the following children:
+        - `<isCivilian>` (e.g., True)
+          - Flag indicating whether the nomination is for a civilian position.
+          - Possible values are "True" or "False".
+        - `<inMilitary>` (e.g., False)
+          - Flag indicating whether the nomination is for a military position.
+          - Possible values are "True" or "False".
+    - `<updateDate>` (e.g., 2022-08-02 04:25:19+00:00)
+      - Date of update in Congress.gov
+    - `<latestAction>`
+      - Container for the latest action taken on the nomination. A `<latestAction>` element may contain the following children:
+        - `<actionDate>`(e.g., 2022-08-01)
+          - The date of the latest action on the nomination.
+        - `<text>` (e.g., Received in the Senate and referred to the Committee on the Judiciary.)
+          - The text of the latest action taken on the nomination.
+        - `<url>` (e.g., <https://api.congress.gov/v3/nomination/117/2439>)
+          - A referrer URL to the nomination item in the API. Documentation for the nomination endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/NominationEndpoint.md).
 
 ### Senate Communications Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<senateCommunications>`
 
-Parent container for communications associated with a Senate committee (the below data is taken from https://api.congress.gov/v3/committee/senate/ssas00/senate-communication?api_key=). The `<senateCommunications>` element may contain the following children, which are repeatable:
- - `<item>`
-   - `<chamber>` (e.g., Senate)
-     - The chamber where the communication was received. This value will always be set to "Senate".
-   - `<number>` (e.g., 1944)
-     - The assigned communication number.
-   - `<communicationType>`
-     - Container for communication type information. A `<communicationType>` element may include the following children:
-       - `<code>` (e.g., EC)
-         - The code for the type of communication.
-         - Possible values are "EC", "POM", and "PM".
-       - `<name>` (e.g., Executive Communication)
-         - The name of the type of communication.
-         - Possible values are "Executive Communication", "Petition or Memorial", and "Presidential Message".
-       - `<congress>` (e.g., 117)
-         - The congress during which the communication was received.
-       - `<referralDate>` (e.g., 2021-09-14)
-         - The date the communication was referred to the committee.
-       - `<updateDate>` (e.g., 2021-09-15)
-         - The date of update in Congress.gov.
-       - `<url>` (e.g., https://api.congress.gov/v3/senate-communication/117/ec/1944)
-         - A referrer URL to the Senate communication item in the API. Documentation for the Senate communication endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/SenateCommunicationEndpoint.md).
+Parent container for communications associated with a Senate committee (the below data is taken from <https://api.congress.gov/v3/committee/senate/ssas00/senate-communication?api_key>=). The `<senateCommunications>` element may contain the following children, which are repeatable:
+
+- `<item>`
+  - `<chamber>` (e.g., Senate)
+    - The chamber where the communication was received. This value will always be set to "Senate".
+  - `<number>` (e.g., 1944)
+    - The assigned communication number.
+  - `<communicationType>`
+    - Container for communication type information. A `<communicationType>` element may include the following children:
+      - `<code>` (e.g., EC)
+        - The code for the type of communication.
+        - Possible values are "EC", "POM", and "PM".
+      - `<name>` (e.g., Executive Communication)
+        - The name of the type of communication.
+        - Possible values are "Executive Communication", "Petition or Memorial", and "Presidential Message".
+      - `<congress>` (e.g., 117)
+        - The congress during which the communication was received.
+      - `<referralDate>` (e.g., 2021-09-14)
+        - The date the communication was referred to the committee.
+      - `<updateDate>` (e.g., 2021-09-15)
+        - The date of update in Congress.gov.
+      - `<url>` (e.g., <https://api.congress.gov/v3/senate-communication/117/ec/1944>)
+        - A referrer URL to the Senate communication item in the API. Documentation for the Senate communication endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/SenateCommunicationEndpoint.md).

--- a/Documentation/CommitteeReportEndpoint.md
+++ b/Documentation/CommitteeReportEndpoint.md
@@ -1,149 +1,162 @@
 # Committee Report endpoint
+
 ## Coverage
+
 Coverage information for committee reports data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about committee reports data at [About Committee Reports of the U.S. Congress](https://www.congress.gov/help/committee-reports) on Congress.gov.
+
 ## OpenAPI Specification
+
 View OpenAPI Specification on the committee report API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/committee-report/committee_reports).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
-Note that committee report items at the list level can be filtered down by congress (e.g. 117) and by report type (e.g. hrpt) – https://api.congress.gov/v3/committee-report/117/hrpt?api_key=.
+
+Note that committee report items at the list level can be filtered down by congress (e.g. 117) and by report type (e.g. hrpt) – <https://api.congress.gov/v3/committee-report/117/hrpt?api_key>=.
 
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<reports>`
 
  Parent container for committee reports. A `<reports>` element may include the following children:
- - `<item>`
-   - Container for an individual committee report. An `<item>` element is repeatable and may include the following children: 
-     - `<citation>` (e.g., H. Rept. 117-351)
-	   - The report's citation, which consists of the report type, congress number, and the assigned report number. 
-	 - `<url>` (e.g., https://api.congress.gov/v3/committee-report/117/HRPT/351)
-	 	- A referrer URL to the report item in the API.
-     - `<updateDate>` (e.g., 2022-08-13 19:26:27+00:00)
-       -  The date of update in Congress.gov
-     - `<congress>` (e.g., 117)
-       - The congress during which the committee report was produced.
-       - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-     - `<chamber>` (e.g., House)
-       - The chamber where the committee report was produced.
-       - Possible values are "House" and "Senate".
-     - `<type>` (e.g., HRPT)
-       - The type of report.
-       - Possible values are "HRPT", "SRPT", and "ERPT".
-     - `<number>` (e.g., 351)
-       - The assigned committee report number.
-     - `<part>` (e.g., 1)
-       - The part number of the report. 
-       - Committee reports without parts will have a value of 1. If there are multiple parts, the number value may be 2, 3, etc.
+
+- `<item>`
+  - Container for an individual committee report. An `<item>` element is repeatable and may include the following children:
+    - `<citation>` (e.g., H. Rept. 117-351)
+      - The report's citation, which consists of the report type, congress number, and the assigned report number.
+    - `<url>` (e.g., <https://api.congress.gov/v3/committee-report/117/HRPT/351>)
+      - A referrer URL to the report item in the API.
+    - `<updateDate>` (e.g., 2022-08-13 19:26:27+00:00)
+      - The date of update in Congress.gov
+    - `<congress>` (e.g., 117)
+      - The congress during which the committee report was produced.
+      - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
+    - `<chamber>` (e.g., House)
+      - The chamber where the committee report was produced.
+      - Possible values are "House" and "Senate".
+    - `<type>` (e.g., HRPT)
+      - The type of report.
+      - Possible values are "HRPT", "SRPT", and "ERPT".
+    - `<number>` (e.g., 351)
+      - The assigned committee report number.
+    - `<part>` (e.g., 1)
+      - The part number of the report.
+      - Committee reports without parts will have a value of 1. If there are multiple parts, the number value may be 2, 3, etc.
 
 ### Item Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<committeeReports>`
 
 Parent container for multiple committee report parts within a single report. A `<committeeReports>` element may include the following children:
- -  `<committeeReport>`
-    - Container for a single report or report part. A `<committeeReport>` element may include the following children:
-	  - `<committees>`
-        - Container for the committees associated with a report. A `<committees>` element may include the following children, which are repeatable:
-        	- `<item>` 
-        		- Container for an individual committee associated with a report. An `<item>` element is repeatable and may include the following children:
-        			- `<url>` (e.g., https://api.congress.gov/v3/committee/house/hsba00)
-        				- A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
-        			- `<systemCode>` (e.g., hsba00)
-        				- Unique ID value for the committee.
-        			- `<name>` Financial Services Committee
-        				- The name of the committee.
-	  - `<congress>` (e.g., 117)
-	  	- The congress during which the committee report was produced.
-	  	- View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-	  - `<chamber>` (e.g., House)
-	  	- The chamber where the committee report was produced.
-	  	- Possible values are "House" and "Senate".
-	  - `<sessionNumber>` (e.g., 2)
-	  	- The session of congress during which the report was produced.
-	  	- Possible values are "1" and "2".
-	  - `<citation>` (e.g., H. Rept. 117-351)
-	  	- The report's citation, which consists of the report type, congress number, and the assigned report number. 
-	  - `<number>` (e.g., 351)
-		- The assigned committee report number.
-	  - `<part>` (e.g., 1)
-		- The part number of the report. 
-		- Committee reports without parts will have a value of 1. If there are multiple parts, the number value may be 2, 3, etc.
-	  - `<type>` (e.g., HRPT)
-	  	- The type of report.
-		- Possible values are "HRPT", "SRPT", and "ERPT".	 
-	  - `<updateDate>` (e.g., 2022-06-21T23:26:16Z)
-	  	- The date of update in Congress.gov.
-	  - `<isConferenceReport>` (e.g., False)
-	  	- Flag indicating whether the report is a conference report.
-	  	- Possible values are "True" or "False".
-	  - `<title>` (e.g., EXPANDING FINANCIAL ACCESS FOR UNDERSERVED COMMUNITIES ACT)
-	  	- The title of the committee report.
-	  - `<issueDate>` (e.g., 2022-06-07T04:00:00Z)
-	 	- The date the report was issued.
-	  - `<reportType>` (e.g., H.Rept.)
-	 	- The type of report.
-	 	- Possible values are "S.Rept", "H.Rept", and "Ex.Rept".
-	  - `<text>`
-	 	- Container for committee report text. A `<text>` element may include the following children: 
-	 		- `<count>` (e.g., 2)
-	 			- The number of text formats for the committee report.
-	 		- `<url>` (e.g., https://api.congress.gov/v3/committee-report/117/hrpt/351/text)
-	 			- A referrer URL to the text level of the committee report API. Click [here](#text-level) for more information about the text level. 
-	 - `<associatedTreaties>`
-	   - Container for associated treaties to the executive report. An `<associatedTreaties>` element may include the following children (the below data is taken from https://api.congress.gov/v3/committee-report/117/erpt/5?api_key=):
-	     - `<item>` 
-	       - Container for an associated treaty. An `<item>` element is repeatable and may include the following children:
-	         - `<congress>` (e.g., 117)
-	           - The congress during which the treaty was submitted. 
-	           - Unlike bills and resolutions, treaties remain active in a congress until they are ratified or returned to the President.
-	         - `<number>` (e.g., 3)
-	           - The assigned treaty number.
-	         - `<part>`
-	           - The treaty part, if the treaty was partitioned.
-	           - Possible values include "A", "B", "C", etc.
-	         - `<url>` (e.g., https://api.congress.gov/v3/treaty/117/3)
-	           - A referrer URL to the treaty item on the API.
-	           - Documentation for the treaty endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/TreatyEndpoint.md).
-	 - `<associatedBill>`
-	   - Container for associated bills to the committee report. An `<associatedBill>` element may include the following children:
-	     - `<item>` 
-	       - Container for an associated bill. An `<item>` element is repeatable and may include the following children:
-	         - `<congress>` (e.g., 117)
-	           - The congress during which a bill or resolution was introduced or submitted.
-	         - `<type>` (e.g., HR)
-	           - The type of bill or resolution.
-	           - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
-	         - `<number>` (e.g., 7003)
-	           - The assigned bill or resolution number.
-	         - `<url>` (e.g., https://api.congress.gov/v3/bill/117/hr/7003)
-	           - A referrer URL to the bill or resolution item in the API. Documentation for the bill endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md). 
-		      
+
+- `<committeeReport>`
+  - Container for a single report or report part. A `<committeeReport>` element may include the following children:
+    - `<committees>`
+      - Container for the committees associated with a report. A `<committees>` element may include the following children, which are repeatable:
+        - `<item>`
+          - Container for an individual committee associated with a report. An `<item>` element is repeatable and may include the following children:
+        - `<url>` (e.g., <https://api.congress.gov/v3/committee/house/hsba00>)
+          - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
+        - `<systemCode>` (e.g., hsba00)
+          - Unique ID value for the committee.
+        - `<name>` Financial Services Committee
+          - The name of the committee.
+    - `<congress>` (e.g., 117)
+      - The congress during which the committee report was produced.
+      - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
+    - `<chamber>` (e.g., House)
+      - The chamber where the committee report was produced.
+      - Possible values are "House" and "Senate".
+    - `<sessionNumber>` (e.g., 2)
+      - The session of congress during which the report was produced.
+      - Possible values are "1" and "2".
+    - `<citation>` (e.g., H. Rept. 117-351)
+      - The report's citation, which consists of the report type, congress number, and the assigned report number.
+    - `<number>` (e.g., 351)
+      - The assigned committee report number.
+    - `<part>` (e.g., 1)
+      - The part number of the report.
+      - Committee reports without parts will have a value of 1. If there are multiple parts, the number value may be 2, 3, etc.
+    - `<type>` (e.g., HRPT)
+      - The type of report.
+      - Possible values are "HRPT", "SRPT", and "ERPT".  
+    - `<updateDate>` (e.g., 2022-06-21T23:26:16Z)
+      - The date of update in Congress.gov.
+    - `<isConferenceReport>` (e.g., False)
+      - Flag indicating whether the report is a conference report.
+      - Possible values are "True" or "False".
+    - `<title>` (e.g., EXPANDING FINANCIAL ACCESS FOR UNDERSERVED COMMUNITIES ACT)
+      - The title of the committee report.
+    - `<issueDate>` (e.g., 2022-06-07T04:00:00Z)
+      - The date the report was issued.
+    - `<reportType>` (e.g., H.Rept.)
+      - The type of report.
+      - Possible values are "S.Rept", "H.Rept", and "Ex.Rept".
+    - `<text>`
+      - Container for committee report text. A `<text>` element may include the following children:
+        - `<count>` (e.g., 2)
+          - The number of text formats for the committee report.
+        - `<url>` (e.g., <https://api.congress.gov/v3/committee-report/117/hrpt/351/text>)
+          - A referrer URL to the text level of the committee report API. Click [here](#text-level) for more information about the text level.
+  - `<associatedTreaties>`
+    - Container for associated treaties to the executive report. An `<associatedTreaties>` element may include the following children (the below data is taken from <https://api.congress.gov/v3/committee-report/117/erpt/5?api_key>=):
+      - `<item>`
+        - Container for an associated treaty. An `<item>` element is repeatable and may include the following children:
+          - `<congress>` (e.g., 117)
+            - The congress during which the treaty was submitted.
+            - Unlike bills and resolutions, treaties remain active in a congress until they are ratified or returned to the President.
+          - `<number>` (e.g., 3)
+            - The assigned treaty number.
+          - `<part>`
+            - The treaty part, if the treaty was partitioned.
+            - Possible values include "A", "B", "C", etc.
+          - `<url>` (e.g., <https://api.congress.gov/v3/treaty/117/3>)
+            - A referrer URL to the treaty item on the API.
+            - Documentation for the treaty endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/TreatyEndpoint.md).
+  - `<associatedBill>`
+    - Container for associated bills to the committee report. An `<associatedBill>` element may include the following children:
+      - `<item>`
+        - Container for an associated bill. An `<item>` element is repeatable and may include the following children:
+          - `<congress>` (e.g., 117)
+            - The congress during which a bill or resolution was introduced or submitted.
+          - `<type>` (e.g., HR)
+            - The type of bill or resolution.
+            - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
+          - `<number>` (e.g., 7003)
+            - The assigned bill or resolution number.
+          - `<url>` (e.g., <https://api.congress.gov/v3/bill/117/hr/7003>)
+            - A referrer URL to the bill or resolution item in the API. Documentation for the bill endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
+
 ### Text Level
+
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<textVersions>`
 
 Parent container for the text versions of a committee report. A `<textVersion>` element may include the following children, which are repeatable:
-- `<item>` 
+
+- `<item>`
   - Container for a text version of the report. An `<item>` element is repeatable and may include the following children:
     - `<formats>`
-	  - Container for a text format for the committee report. A `<formats>` element may include the following children:
-	    - `<item>`
-		  - Container for a report version. An `<item>` element is repeatable and may include the following children:
-		    - `<url>` (e.g., https://www.congress.gov/117/crpt/hrpt351/generated/CRPT-117hrpt351.htm)
-			  - The URL for the text version format for the committee report. 
-			  - Work is scheduled to make the URL absolute, instead of relative.
-			- `<type>` (e.g., Formatted Text)
-			  - The format type for the committee report text. 
-			  - Possible values are "Formatted Text" and "PDF".
-			- `<isErrata>` (e.g., N)
-			  - Flag indicating whether the text is errata or not.
-			  - Possible values are "Y" or "N".
+      - Container for a text format for the committee report. A `<formats>` element may include the following children:
+        - `<item>`
+          - Container for a report version. An `<item>` element is repeatable and may include the following children:
+            - `<url>` (e.g., <https://www.congress.gov/117/crpt/hrpt351/generated/CRPT-117hrpt351.htm>)
+              - The URL for the text version format for the committee report.
+              - Work is scheduled to make the URL absolute, instead of relative.
+            - `<type>` (e.g., Formatted Text)
+              - The format type for the committee report text.
+              - Possible values are "Formatted Text" and "PDF".
+            - `<isErrata>` (e.g., N)
+              - Flag indicating whether the text is errata or not.
+              - Possible values are "Y" or "N".

--- a/Documentation/CongressEndpoint.md
+++ b/Documentation/CongressEndpoint.md
@@ -1,13 +1,20 @@
 # Congress endpoint
+
 ## Coverage
+
 Coverage information for congress data in the API can be found at the [Congresses field values list](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Information on past session dates can be found on Congress.gov at the [Dates of Past Sessions](https://www.congress.gov/past-days-in-session).
+
 ## OpenAPI Specification
+
 View OpenAPI Specification on the congress API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/congress/congress_list).
+
 ## Elements and Descriptions
-The section below details available element names, their descriptions, and possible values. 
+
+The section below details available element names, their descriptions, and possible values.
+
 ### List Level
 
-Note that congress items at the list level cannot be filtered (https://api.congress.gov/v3/congress?api_key=).
+Note that congress items at the list level cannot be filtered (<https://api.congress.gov/v3/congress?api_key>=).
 
 `<api-root>`
 
@@ -16,7 +23,8 @@ The `<api-root>` is only present in the XML format.
 `<congresses>`
 
 Parent container for congress and congressional sessions. A `<congresses>` element may include the following children:
-- `<item>` 
+
+- `<item>`
   - Container for a congress item. An `<item>` element is repeatable and may include the following children:
     - `<name>` (e.g. 116th Congress)
       - The name of the congress.
@@ -24,7 +32,7 @@ Parent container for congress and congressional sessions. A `<congresses>` eleme
       - The start year for the congress. Congresses span over a two-year period.
     - `<endYear>` (e.g. 2020)
       - The end year for the congress. Congresses span over a two-year period.
-    - `<sessions>` 
+    - `<sessions>`
       - Container for sessions of congress. A `<sessions>` element may include the following children:
         - `<item>`
           - Container for a single session of congress for a chamber. An `<item>` element is repeatable and may include the following children:
@@ -32,7 +40,7 @@ Parent container for congress and congressional sessions. A `<congresses>` eleme
               - The chamber associated with the session of congress.
               - Possible values are "House" and "Senate".
             - `<type>` (e.g. R)
-              - The type of session. 
+              - The type of session.
               - Possible values are "R" and "S" where "R" stands for "Regular" and "S" stands for "Special".
             - `<startDate>` (e.g. 2019-01-03)
               - The start date of the session.
@@ -41,7 +49,9 @@ Parent container for congress and congressional sessions. A `<congresses>` eleme
             - `<number>` (e.g. 1)
               - The assigned session's number.
               - For special sessions, this value is suppressed.
+
 ### Item Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -49,6 +59,7 @@ The `<api-root>` is only present in the XML format.
 `<congress>`
 
 Parent container for a congress and its congressional sessions. A `<congress>` element may include the following children:
+
 - `<sessions>`
   - Container for sessions of congress. A `<sessions>` element may include the following children:
     - `<item>`
@@ -57,7 +68,7 @@ Parent container for a congress and its congressional sessions. A `<congress>` e
           - The chamber associated with the session of congress.
           - Possible values are "House" and "Senate".
         - `<type>` (e.g. R)
-          - The type of session. 
+          - The type of session.
           - Possible values are "R" and "S" where "R" stands for "Regular" and "S" stands for "Special".
         - `<startDate>` (e.g. 2019-01-03)
           - The start date of the session.
@@ -75,6 +86,6 @@ Parent container for a congress and its congressional sessions. A `<congress>` e
 - `<updateDate>` (e.g. 2019-01-03T18:37:12Z)
   - The date of update in Congress.gov.
 - `<number>` (e.g. 116)
-  - The congress number. 
-- `<url>` (e.g. https://api.congress.gov/v3/congress/116)
-  - A referrer URL to the congress item in the API.    
+  - The congress number.
+- `<url>` (e.g. <https://api.congress.gov/v3/congress/116>)
+  - A referrer URL to the congress item in the API.

--- a/Documentation/CongressionalRecordEndpoint.md
+++ b/Documentation/CongressionalRecordEndpoint.md
@@ -1,107 +1,115 @@
 # Congressional Record endpoint
+
 ## Coverage
-Coverage information for congressional record data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Note that while the Bound Congressional Record is available in Congress.gov, it is not yet available in the API. Read more about Congressional Record data at [About the Congressional Record](https://www.congress.gov/help/congressional-record) on Congress.gov. 
+
+Coverage information for congressional record data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Note that while the Bound Congressional Record is available in Congress.gov, it is not yet available in the API. Read more about Congressional Record data at [About the Congressional Record](https://www.congress.gov/help/congressional-record) on Congress.gov.
+
 ## OpenAPI Specification
+
 View OpenAPI Specification on the congressional record API and available parameters at [https://api.congress.gov](https://api.congress.gov/#/congressional-record/congressional_record_list).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
 
-Note that congressional record items can be filtered down to a specific year, month, or date by adding ?y=YYYY&m=MM&d=DD to the request URL (e.g., https://api.congress.gov/v3/congressional-record/?y=2022&m=8&d=16&api_key=)
+Note that congressional record items can be filtered down to a specific year, month, or date by adding ?y=YYYY&m=MM&d=DD to the request URL (e.g., <https://api.congress.gov/v3/congressional-record/?y=2022&m=8&d=16&api_key>=)
 
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
-`<Results>` 
+`<Results>`
 
 Parent container for congressional record issues. A `<Results>` element may include the following children:
- - `<Issues>`
-   - Container for congressional record issues. An `<Issues>` element may include the following children:
-     - `<item>`
-       - Container for an individual congressional record issue. An `<item>` element is repeatable and may include the following children: 
-           - `<Congress>` (e.g., 117)
-              - The congress associated with the congressional record issue.
-              - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-           - `<Issue>` (e.g., 136)
-              - The congressional record's issue number.
-           - `<Links>`
-              - Container for links to the individual sections of the issue. A `<Links>` element may include the following children:
-                 - `<Digest>`
-                      - Container for the Daily Digest section of the issue. A `<Digest>` element may include the following children:
-                          - `<Label>` (e.g., Daily Digest)
-                             - The name of the section.
-                           - `<Ordinal>` (e.g., 1)
-                             - The sort order number used for the section's placement on Congress.gov.
-                           - `<PDF>`
-                             - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
-                                - `<item>`
-                              - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
-                             - `<Part>` (e.g., 1)
-                               - Number assigned to individual PDFs that comprise a single section. If there are multiple Daily Digest section parts, the numbers will be sequential.
-                             - `<Url>` (e.g, https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-dailydigest.pdf)
-                               - The URL to the individual Daily Digest section PDF.
-                  - `<Remarks>`
-                      - Container for the Extension of Remarks section of the issue. A `<Remarks>` element may include the following children:
-                          - `<Label>` (e.g., Extension of Remarks Section)
-                             - The name of the section.
-                           - `<Ordinal>` (e.g., 4)
-                             - The sort order number used for the section's placement on Congress.gov.
-                           - `<PDF>`
-                             - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
-                                - `<item>`
-                              - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
-                             - `<Part>` (e.g., 1)
-                               - Number assigned to individual PDFs that comprise a single section. If there are multiple Extension of Remarks section parts, the numbers will be sequential.
-                             - `<Url>` (e.g, https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-extensions.pdf)
-                               - The URL to the individual Extension of Remarks section PDF.
-                 - `<House>`
-                      - Container for the House section of the issue. A `<House>` element may include the following children:
-                          - `<Label>` (e.g., House Section)
-                             - The name of the section.
-                           - `<Ordinal>` (e.g., 3)
-                             - The sort order number used for the section's placement on Congress.gov.
-                           - `<PDF>`
-                             - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
-                                - `<item>`
-                              - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
-                             - `<Part>` (e.g., 1)
-                               - Number assigned to individual PDFs that comprise a single section. If there are multiple House section parts, the numbers will be sequential.
-                             - `<Url>` (e.g, https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-house.pdf)
-                               - The URL to the individual House section PDF.
-                 - `<Senate>`
-                      - Container for the Senate section of the issue. A `<Senate>` element may include the following children:
-                          - `<Label>` (e.g., Senate Section)
-                             - The name of the section.
-                           - `<Ordinal>` (e.g., 2)
-                             - The sort order number used for the section's placement on Congress.gov.
-                           - `<PDF>`
-                             - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
-                                - `<item>`
-                              - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
-                             - `<Part>` (e.g., 1)
-                               - Number assigned to individual PDFs that comprise a single section. If there are multiple Senate section parts, the numbers will be sequential.
-                             - `<Url>` (e.g, https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-senate.pdf)
-                               - The URL to the individual Senate section PDF.
-                 - `<FullRecord>`
-                      - Container for the Entire Issue section of the issue. A `<FullRecord>` element may include the following children:
-                          - `<Label>` (e.g., Entire Issue)
-                             - The name of the section.
-                           - `<Ordinal>` (e.g., 5)
-                             - The sort order number used for the section's placement on Congress.gov.
-                           - `<PDF>`
-                             - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
-                                - `<item>`
-                              - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
-                             - `<Part>` (e.g., 1)
-                               - Number assigned to individual PDFs that comprise a single section. If there are multiple Entire Issue section parts, the numbers will be sequential.
-                             - `<Url>` (e.g, https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16.pdf)
-                               - The URL to the individual Entire Issue section PDF.
-		 - `<PublishDate>` (e.g., 2022-08-16)
-		   - The publication date of the issue.
-		 - `<Session>` (e.g., 2)
-		   - The session of Congress.
-		   - Possible values are "1" and "2".
-		 - `<Volume>` (e.g., 168)
-		   - The volume number of the issue. 
-			- View a [field values list of Congressional Record Volumes](https://www.congress.gov/help/field-values/congressional-record-volumes) on Congress.gov.
+
+- `<Issues>`
+  - Container for congressional record issues. An `<Issues>` element may include the following children:
+    - `<item>`
+      - Container for an individual congressional record issue. An `<item>` element is repeatable and may include the following children:
+        - `<Congress>` (e.g., 117)
+          - The congress associated with the congressional record issue.
+          - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
+        - `<Issue>` (e.g., 136)
+          - The congressional record's issue number.
+        - `<Links>`
+          - Container for links to the individual sections of the issue. A `<Links>` element may include the following children:
+            - `<Digest>`
+              - Container for the Daily Digest section of the issue. A `<Digest>` element may include the following children:
+                - `<Label>` (e.g., Daily Digest)
+                  - The name of the section.
+                - `<Ordinal>` (e.g., 1)
+                  - The sort order number used for the section's placement on Congress.gov.
+                - `<PDF>`
+                  - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
+                    - `<item>`
+                  - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
+                  - `<Part>` (e.g., 1)
+                    - Number assigned to individual PDFs that comprise a single section. If there are multiple Daily Digest section parts, the numbers will be sequential.
+                  - `<Url>` (e.g, <https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-dailydigest.pdf>)
+                    - The URL to the individual Daily Digest section PDF.
+            - `<Remarks>`
+              - Container for the Extension of Remarks section of the issue. A `<Remarks>` element may include the following children:
+                - `<Label>` (e.g., Extension of Remarks Section)
+                  - The name of the section.
+                - `<Ordinal>` (e.g., 4)
+                  - The sort order number used for the section's placement on Congress.gov.
+                - `<PDF>`
+                  - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
+                    - `<item>`
+                  - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
+                  - `<Part>` (e.g., 1)
+                    - Number assigned to individual PDFs that comprise a single section. If there are multiple Extension of Remarks section parts, the numbers will be sequential.
+                  - `<Url>` (e.g, <https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-extensions.pdf>)
+                    - The URL to the individual Extension of Remarks section PDF.
+            - `<House>`
+              - Container for the House section of the issue. A `<House>` element may include the following children:
+                - `<Label>` (e.g., House Section)
+                  - The name of the section.
+                - `<Ordinal>` (e.g., 3)
+                  - The sort order number used for the section's placement on Congress.gov.
+                - `<PDF>`
+                  - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
+                    - `<item>`
+                  - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
+                  - `<Part>` (e.g., 1)
+                    - Number assigned to individual PDFs that comprise a single section. If there are multiple House section parts, the numbers will be sequential.
+                  - `<Url>` (e.g, <https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-house.pdf>)
+                    - The URL to the individual House section PDF.
+            - `<Senate>`
+              - Container for the Senate section of the issue. A `<Senate>` element may include the following children:
+                - `<Label>` (e.g., Senate Section)
+                  - The name of the section.
+                - `<Ordinal>` (e.g., 2)
+                  - The sort order number used for the section's placement on Congress.gov.
+                - `<PDF>`
+                  - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
+                    - `<item>`
+                  - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
+                  - `<Part>` (e.g., 1)
+                    - Number assigned to individual PDFs that comprise a single section. If there are multiple Senate section parts, the numbers will be sequential.
+                  - `<Url>` (e.g, <https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16-senate.pdf>)
+                    - The URL to the individual Senate section PDF.
+            - `<FullRecord>`
+              - Container for the Entire Issue section of the issue. A `<FullRecord>` element may include the following children:
+                - `<Label>` (e.g., Entire Issue)
+                  - The name of the section.
+                - `<Ordinal>` (e.g., 5)
+                  - The sort order number used for the section's placement on Congress.gov.
+                - `<PDF>`
+                  - Container for the PDF text format for the section. A `<PDF>` element may include the following children:
+                    - `<item>`
+                  - Container for the individual PDF text format for the section. Multiple PDFs may be used to deliver the entire section. An `<item>` element is repeatable and may include the following children:
+                  - `<Part>` (e.g., 1)
+                    - Number assigned to individual PDFs that comprise a single section. If there are multiple Entire Issue section parts, the numbers will be sequential.
+                  - `<Url>` (e.g, <https://www.congress.gov/117/crec/2022/08/16/168/136/CREC-2022-08-16.pdf>)
+                    - The URL to the individual Entire Issue section PDF.
+        - `<PublishDate>` (e.g., 2022-08-16)
+          - The publication date of the issue.
+        - `<Session>` (e.g., 2)
+          - The session of Congress.
+          - Possible values are "1" and "2".
+        - `<Volume>` (e.g., 168)
+          - The volume number of the issue.
+          - View a [field values list of Congressional Record Volumes](https://www.congress.gov/help/field-values/congressional-record-volumes) on Congress.gov.

--- a/Documentation/HouseCommunicationEndpoint.md
+++ b/Documentation/HouseCommunicationEndpoint.md
@@ -1,48 +1,59 @@
 # House communication endpoint
-## Coverage 
-Coverage information for House communications data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about House communications data at [About Communications to the House](https://www.congress.gov/help/house-communications) on Congress.gov.
-## OpenAPI Specification
-View OpenAPI Specification on the House communications API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/house-communication/house_communication). 
-## Elements and Descriptions
-The section below details available element names, their description, and possible values.
-### List Level
-Note that House communication items at the list level can be filtered down by congress (e.g. 117) and by communication type (e.g. ec) - https://api.congress.gov/v3/house-communication/117/ec?api_key=. 
 
-`<api-root>` 
+## Coverage
+
+Coverage information for House communications data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about House communications data at [About Communications to the House](https://www.congress.gov/help/house-communications) on Congress.gov.
+
+## OpenAPI Specification
+
+View OpenAPI Specification on the House communications API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/house-communication/house_communication).
+
+## Elements and Descriptions
+
+The section below details available element names, their description, and possible values.
+
+### List Level
+
+Note that House communication items at the list level can be filtered down by congress (e.g. 117) and by communication type (e.g. ec) - <https://api.congress.gov/v3/house-communication/117/ec?api_key>=.
+
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
 `<houseCommunications>`
 
 Parent container for House communications. A `<houseCommunications>` element may include the following children:
-- `<item>` 
+
+- `<item>`
   - Container for a House communication item. An `<item>` element is repeatable and may include the following children:
     - `<chamber>` (e.g. House)
-      - The chamber where the communication was received. This value will always be set to "House".    
+      - The chamber where the communication was received. This value will always be set to "House".
     - `<communicationNumber>` (e.g. 1)
       - The assigned communication number.
-    -  `<communicationType>`
-        - Container for communication type information. A `<communicationType>` element may include the following children:
-          -  `<code>` (e.g. EC)
-             - The code for the type of communication. 
-             - Possible values are "EC", "PM", "PT", and "ML".
-          - `<name>` (e.g. Executive Communication)
-            - The name of the type of communication.
-            - Possible values are "Executive Communication", "Presidential Message", "Petition", and "Memorial".
+    - `<communicationType>`
+      - Container for communication type information. A `<communicationType>` element may include the following children:
+        - `<code>` (e.g. EC)
+          - The code for the type of communication.
+          - Possible values are "EC", "PM", "PT", and "ML".
+        - `<name>` (e.g. Executive Communication)
+          - The name of the type of communication.
+          - Possible values are "Executive Communication", "Presidential Message", "Petition", and "Memorial".
     - `<congressNumber>` (e.g. 115)
-      - The congress during which the communication was received. 
+      - The congress during which the communication was received.
       - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-    - `<url>` (e.g. https://api.congress.gov/v3/house-communication/115/ec/1)
-        - A referrer URL to the communication item in the API.
+    - `<url>` (e.g. <https://api.congress.gov/v3/house-communication/115/ec/1>)
+      - A referrer URL to the communication item in the API.
 
 ### Item Level
-`<api-root>` 
+
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
-`<house-communication>` 
+`<house-communication>`
 
 Parent container for a House communication item. A `<house-communication>` element may include the following children:
+
 - `<chamber>` (e.g. House)
   - The chamber where the communication was received. This value will always be set to "House".
 - `<communicationNumber>` (e.g. 1)
@@ -56,17 +67,17 @@ Parent container for a House communication item. A `<house-communication>` eleme
       - The name of the type of communication.
       - Possible values are "Executive Communication", "Presidential Message", "Petition", and "Memorial".
 - `<congressNumber>` (e.g. 115)
-  - The congress during which the communication was received. 
+  - The congress during which the communication was received.
   - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
 - `<abstract>` (e.g. A letter from the Clerk, U.S. House of Representatives, transmitting a list of reports created by the Clerk, pursuant to Rule II, clause 2(b), of the Rules of the House; (H. Doc. No. 115–4); to the Committee on House Administration and ordered to be printed.)
-  - The abstract text for the communication. 
+  - The abstract text for the communication.
 - `<congressionalRecordDate>` (e.g. 2017-01-03)
-  - The date the communication was published in the Congressional Record. 
+  - The date the communication was published in the Congressional Record.
 - `<committees>`
   - Container for committees associated with the communication. A `<committees>` element may include the following children:
-      - `<item>`
-          - Container for a single committee associated with the communication. An `<item>` element is repeatable and may include the following children:
-              - `<name>` (e.g. House Administration Committee)
-                  - The name of the committee.
-              - `<referredToCommitteeDate>` (e.g. 2017-01-03)
-                  - The date the communication was referred to the committee.
+    - `<item>`
+      - Container for a single committee associated with the communication. An `<item>` element is repeatable and may include the following children:
+        - `<name>` (e.g. House Administration Committee)
+          - The name of the committee.
+        - `<referredToCommitteeDate>` (e.g. 2017-01-03)
+          - The date the communication was referred to the committee.

--- a/Documentation/HouseRequirementEndpoint.md
+++ b/Documentation/HouseRequirementEndpoint.md
@@ -1,37 +1,48 @@
 # House requirement endpoint
-## Coverage 
+
+## Coverage
+
 Coverage information for House requirements data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about House requirements data within [About Communications to the House](https://www.congress.gov/help/house-communications) on Congress.gov.
+
 ## OpenAPI Specification
-View OpenAPI Specification on the House requirement API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/house-requirement/house_requirement). 
+
+View OpenAPI Specification on the House requirement API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/house-requirement/house_requirement).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
+
 Note that House requirement items at the list level cannot be filtered ([https://api.congress.gov/v3/house-requirement](https://api.congress.gov/v3/house-requirement)).
 
-`<api-root>` 
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
 `<houseReqirements>`
 
 Parent container for House requirements. A `<houseReqirements>` element may include the following children:
-- `<item>` 
+
+- `<item>`
   - Container for a House requirement item. An `<item>` element is repeatable and may include the following children:
     - `<number>` (e.g. 12478)
       - The assigned requirement number.
     - `<updateDate>` (e.g. 2021-11-05)
       - The date of update in Congress.gov.
-    - `<url>` (e.g. https://api.congress.gov/v3/house-requirement/12478)
-        - A referrer URL to the House requirement item in the API.
+    - `<url>` (e.g. <https://api.congress.gov/v3/house-requirement/12478>)
+      - A referrer URL to the House requirement item in the API.
 
 ### Item Level
-`<api-root>` 
+
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
-`<houseRequirement>` 
+`<houseRequirement>`
 
 Parent container for a House requirement item. A `<houseRequirement>` element may include the following children:
+
 - `<number>` (e.g. 12478)
   - The assigned House requirement number.
 - `<updateDate>` (e.g. 2021-11-05)

--- a/Documentation/MemberEndpoint.md
+++ b/Documentation/MemberEndpoint.md
@@ -1,12 +1,20 @@
 # Member endpoint
+
 ## Coverage
+
 Coverage information for member data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about member data at [About Congressional Member Profiles](https://www.congress.gov/help/members) on Congress.gov.
+
 ## OpenAPI Specification
-View OpenAPI Specification on the member API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/member/member_list). 
+
+View OpenAPI Specification on the member API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/member/member_list).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
-Note that member items at the list level cannot be filtered (https://api.congress.gov/v3/member?api_key=).
+
+Note that member items at the list level cannot be filtered (<https://api.congress.gov/v3/member?api_key>=).
 
 `<api-root>`
 
@@ -15,39 +23,42 @@ The `<api-root>` is only present in the XML format.
 `<members>`
 
 Parent container for all member entries. A `<members>` element may include the following children:
+
 - `<member>`
   - Container for an individual member’s entry.  A `<member>` element may include the following children:
     - `<bioguideID>` (e.g., L000174)
-      - The unique ID value that originates in the [Biographical Directory of the United States Congress, 1774-Present](https://bioguide.congress.gov/). 
+      - The unique ID value that originates in the [Biographical Directory of the United States Congress, 1774-Present](https://bioguide.congress.gov/).
       - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
-     - `<state>` (e.g., Vermont)
-       - The state represented by the member.
-     - `<party>`  (e.g., Democrat)
-        - The political party of the member.
-        - Possible values are "Democratic", "Independent", "Independent Democrat", "Libertarian", or "Republican".
+    - `<state>` (e.g., Vermont)
+      - The state represented by the member.
+    - `<party>`  (e.g., Democrat)
+      - The political party of the member.
+      - Possible values are "Democratic", "Independent", "Independent Democrat", "Libertarian", or "Republican".
     - `<district>`  
       - The Congressional district represented by the member (exclusive to House). The value of zero indicates the state, district or territory has only one member in the House.
-     - `<name>`  (e.g.,  Leahy, Patrick J.)
-        - The name of the member in last-name-first order.
-      - `<served>`
-        - Container for service history of the member. A `<served>` element may include the following children:
-            - `<House>` or `<Senate>`
-                - The chamber in which the member served. A `<House>` or `<Senate>` element may include the following children:
-                    - `<item>`
-                        - Container for member’s years of service in the designated chamber. An `<item>` element may include the following children:
-                             - `<start>` (e.g., 1975)
-                                  - The year in which the member began serving in the designated chamber.
-                             - `<end>` (e.g., 1990)
-                                  - The year in which the member ceased serving in the designated chamber.
-      - `<url>`  (e.g., https://api.congress.gov/v3/member/L000174)
-          - A referrer URL to the member item in the API.
-      - `<depiction>`
-          -	Container for the member’s current official portrait. The `<depiction>` element may include the following children:
-              - `<imageUrl>` (e.g. https://www.congress.gov/img/member/l000174_200.jpg)
-                  - The member's current portrait on Congress.gov.
-              - `<attribution>` (e.g. `<a href="http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm">Courtesy U.S. Senate Historical Office</a>`)
-                  - The source of the image.
+    - `<name>`  (e.g.,  Leahy, Patrick J.)
+      - The name of the member in last-name-first order.
+    - `<served>`
+      - Container for service history of the member. A `<served>` element may include the following children:
+        - `<House>` or `<Senate>`
+          - The chamber in which the member served. A `<House>` or `<Senate>` element may include the following children:
+            - `<item>`
+              - Container for member’s years of service in the designated chamber. An `<item>` element may include the following children:
+                - `<start>` (e.g., 1975)
+                  - The year in which the member began serving in the designated chamber.
+                - `<end>` (e.g., 1990)
+                  - The year in which the member ceased serving in the designated chamber.
+    - `<url>`  (e.g., <https://api.congress.gov/v3/member/L000174>)
+      - A referrer URL to the member item in the API.
+    - `<depiction>`
+      - Container for the member’s current official portrait. The `<depiction>` element may include the following children:
+        - `<imageUrl>` (e.g. <https://www.congress.gov/img/member/l000174_200.jpg>)
+          - The member's current portrait on Congress.gov.
+        - `<attribution>` (e.g. `<a href="http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm">Courtesy U.S. Senate Historical Office</a>`)
+          - The source of the image.
+
 ### Item Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -55,25 +66,26 @@ The `<api-root>` is only present in the XML format.
 `<member-lis>`
 
 Parent container for an individual member’s entry. A `<member>` element may include the following children:
+
 - `<currentMember>` (e.g., True)  
-  - Indicator of whether the member is currently serving. 
+  - Indicator of whether the member is currently serving.
   - Possible values are "True" or "False".
 - `<birthYear>` (e.g., 1940)  
   - Member’s year of birth.
-- `<deathYear>` 
-  - Member’s year of death. 
-- `<updateDate>` (e.g., 2022-05-17T18:44:02Z) 
+- `<deathYear>`
+  - Member’s year of death.
+- `<updateDate>` (e.g., 2022-05-17T18:44:02Z)
   - The date of update in Congress.gov.
 - `<depiction>`
   - Container for the member’s current official portrait. A `<depiction>` element may include the following children:
-    - `<imageUrl>` (e.g., https://www.congress.gov/img/member/l000174_200.jpg)
+    - `<imageUrl>` (e.g., <https://www.congress.gov/img/member/l000174_200.jpg>)
       - The member's current portrait on Congress.gov.
     - `<attribution>` (e.g., `<a href="http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm">Courtesy U.S. Senate Historical Office</a>`)
-      - The source of the image. 
+      - The source of the image.
 - `<terms>`
-  - Container of a member’s terms of service in chronological order. A `<terms>` element may include the following child, which is repeatable: 
-    - `<item>` 
-      - Container for the member’s service in an individual Congress. An `<item>` element is repeatable and may include the following children: 
+  - Container of a member’s terms of service in chronological order. A `<terms>` element may include the following child, which is repeatable:
+    - `<item>`
+      - Container for the member’s service in an individual Congress. An `<item>` element is repeatable and may include the following children:
         - `<memberType>` (e.g., Senator)
           - The membership type.
           - Possible values are "Representative", "Resident Commissioner", "Delgate", or "Senator".
@@ -84,34 +96,34 @@ Parent container for an individual member’s entry. A `<member>` element may in
           - The chamber in which the member served during that Congress.
           - Possible values are "House of Representatives" and "Senate".
         - `<stateCode>` (e.g., VT)
-          - The two-digit postal code abbreviation for the state represented by the member. 
+          - The two-digit postal code abbreviation for the state represented by the member.
         - `<stateName>` (e.g., Vermont)
-          - The name of the state represented by the member. 
+          - The name of the state represented by the member.
         - `<partyName>` (e.g., Democratic)
           - The political party of the member.
           - Possible values are "Democratic", "Independent", "Independent Democrat", "Libertarian", and "Republication".
         - `<partyCode>` (e.g., D)
           - The single letter abbreviation for the political party of the member.
-          - Possible values are "D", "I", "ID", "L", and "R". 
+          - Possible values are "D", "I", "ID", "L", and "R".
         - `<termBeginYear>` (e.g., 1975)
-          - The year in which the member’s service in that Congress began. 
+          - The year in which the member’s service in that Congress began.
         - `<termEndYear>` (e.g., 1977)
-          - The year in which the member’s service in that Congress ended. 
+          - The year in which the member’s service in that Congress ended.
         - `<district>`  
           - The Congressional district represented by the member (exclusive to the House). The value of zero indicates the state, district or territory has only one member in the House.
 - `<identifiers>`
-  - Container for member’s identifying information. The `<identifiers>` element may include the following child: 
+  - Container for member’s identifying information. The `<identifiers>` element may include the following child:
     - `<bioguideID>` (e.g., L000174)
-      - The unique ID value that originates in the [Biographical Directory of the United States Congress, 1774-Present](https://bioguide.congress.gov/). 
-      - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov. 
+      - The unique ID value that originates in the [Biographical Directory of the United States Congress, 1774-Present](https://bioguide.congress.gov/).
+      - View a [field values list of Bioguide identifiers](https://www.congress.gov/help/field-values/member-bioguide-ids) for current and former members in Congress.gov.
 - `<party>` (e.g., Democatic)
-  - The current political party of the member. Note: This does not currently reflect party changes. 
+  - The current political party of the member. Note: This does not currently reflect party changes.
   - Possible values are "Democratic", "Independent", "Independent Democrat", "Libertarian", and "Republication".
 - `<state>` (e.g., Vermont)
   - The state represented by the member.
-- `<district>`   
+- `<district>`
   - The Congressional district represented by the member (exclusive to House). The value of zero indicates the state, district or territory has only one member in the House.
-- `<officialUrl>` (e.g., https://www.leahy.senate.gov/)
+- `<officialUrl>` (e.g., <https://www.leahy.senate.gov/>)
   - The member’s official website.
 - `<honorificName>` (e.g., Mr.)  
   - The honorific title of the member.
@@ -119,52 +131,52 @@ Parent container for an individual member’s entry. A `<member>` element may in
   - The member’s first name.
 - `<middleName>` (e.g., Jospeh)
   - The member’s middle name.
-- `<lastName>` (e.g., Leahy) 
+- `<lastName>` (e.g., Leahy)
   - The member’s last name.
 - `<suffixName>`  
-  - The member’s suffix. 
+  - The member’s suffix.
 - `<nickName>`  
-  - The member’s nickname. 
+  - The member’s nickname.
 - `<directOrderName>` (e.g., Patrick J. Leahy)
-  - The member’s name in first-name-first order. 
+  - The member’s name in first-name-first order.
 - `<invertedOrderName>` (e.g., Leahy, Patrick J.)
-  - The member’s name in last-name-first order. 
+  - The member’s name in last-name-first order.
 - `<addressInformation>`
   - Container for the member’s contact information. An `<addressInformation>` container may include the following children:
-    - `<officeAddress>` (e.g, 437 Russell Senate Office Building Washington, DC 20510) 
-      - The member’s mailing and physical office address in Washington, D.C. The `<officeAddress>` element provides the full address for Senate members and only the House office building information for House members. 
+    - `<officeAddress>` (e.g, 437 Russell Senate Office Building Washington, DC 20510)
+      - The member’s mailing and physical office address in Washington, D.C. The `<officeAddress>` element provides the full address for Senate members and only the House office building information for House members.
     - `<city>` Washington
-      - The city of Washington. 
-    - `<district>` DC 
-      - The two letter postal abbreviation for the District of Columbia. 
+      - The city of Washington.
+    - `<district>` DC
+      - The two letter postal abbreviation for the District of Columbia.
     - `<zipCode>` (e.g., 20510)
-      - The postal zip code for the member’s office in Washington, D.C. 
+      - The postal zip code for the member’s office in Washington, D.C.
     - `<officeTelephone>`
       - Container for the member’s telephone contact information. An `<officeTelephone>` container may include the following child:
         - `<phoneNumber>` (e.g., (202) 224-4242)
-          - The telephone number for the member’s office in Washington, D.C. 
+          - The telephone number for the member’s office in Washington, D.C.
 - `<leadership>`
   - Container for the leadership positions available on Congress.gov that the member has held during their membership/tenure of service. A `<leadership>` container may include the following child, which is repeatable:
     - `<item>`
       - Container for individual leadership positions held by the member during a Congress. An `<item>` container is repeatable and may include the following children:
       - `<type>` (e.g., President Pro Tempore)
-        - The title of the leadership position held by the member. 
+        - The title of the leadership position held by the member.
       - `<congress>` (e.g., 113)
-        - The Congress during which the specified leadership position was held by the member. 
+        - The Congress during which the specified leadership position was held by the member.
       - `<current>` (e.g., False)
         - Indicator whether the leadership position is currently held by the member. NOTE: This value may change from True to False during a Congress.
         - Possible values are "True" or "False".
 - `<sponsoredLegislation>`
   - Container for bills and resolutions sponsored by member. A `<sponsoredLegislation>` container may include the following children:
     - `<count>` (e.g., 1753)
-      - The total number of bills and resolutions sponsored by the member. 
-    - `<url>` (e.g., https://api.congress.gov/v3/member/L000174/sponsored-legislation)
+      - The total number of bills and resolutions sponsored by the member.
+    - `<url>` (e.g., <https://api.congress.gov/v3/member/L000174/sponsored-legislation>)
       - A referrer URL to the sponsored-legislation level of the API. Click [here](#sponsored-legislation-level) for more information about the sponsored-legislation level.
 - `<cosponsoredLegislation>`
   - Container for bills and resolutions cosponsored by member. A `<cosponsoredLegislation>` container may include the following children:
     - `<count>` (e.g., 7470)  
-      - The total number of bills and resolutions cosponsored by the member. 
-    - `<url>` (e.g., https://api.congress.gov/v3/member/L000174/cosponsored-legislation) 
+      - The total number of bills and resolutions cosponsored by the member.
+    - `<url>` (e.g., <https://api.congress.gov/v3/member/L000174/cosponsored-legislation>)
       - A referrer URL to the cosponsored-legislation level of the API. Click [here](#cosponsored-legislation-level) for more information about the cosponsored-legislation level.  
 - `<updateDate>` (e.g., 2022-07-22T18:44:02Z)
   - The date of last update in Congress.gov.
@@ -178,10 +190,11 @@ The `<api-root>` is only present in the XML format.
 `<sponsoredLegislation>`
 
 Parent container for all sponsored bills and resolutions. A `<sponsoredLegislation>` element may include the following children:
+
 - `<item>`
   - Container for an individual bill or resolution sponsored by the member. An `<item>` element may include the following children:
     - `<introducedDate>` (e.g., 2022-06-16)
-      - The date the bill or resolution was introduced. 
+      - The date the bill or resolution was introduced.
     - `<type>` (e.g., S)
       - The type of bill or resolution.
       - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
@@ -202,9 +215,8 @@ Parent container for all sponsored bills and resolutions. A `<sponsoredLegislati
           - The date of the latest action taken on the bill or resolution.
         - `<text>` (e.g., Read twice and referred to the Committee on the Judiciary.)
           - The text of the latest action taken on the bill or resolution.
-    - `<url>` (e.g., https://api.congress.gov/v3/bill/117/s/4417)
+    - `<url>` (e.g., <https://api.congress.gov/v3/bill/117/s/4417>)
       - A referrer URL to the bill item in the API. Documentation for the bill endpoint is [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
-
 
 ### Cosponsored-Legislation Level
 
@@ -215,10 +227,11 @@ The `<api-root>` is only present in the XML format.
 `<cosponsoredLegislation>`
 
 Parent container for all sponsored bills and resolutions. A `<cosponsoredLegislation>` element may include the following children:
+
 - `<item>`
   - Container for an individual bill or resolution sponsored by the member. An `<item>` element may include the following children:
     - `<introducedDate>` (e.g., 2022-07-20)
-      - The date the bill or resolution was introduced. 
+      - The date the bill or resolution was introduced.
     - `<type>` (e.g., SRES)
       - The type of bill or resolution.
       - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
@@ -239,5 +252,5 @@ Parent container for all sponsored bills and resolutions. A `<cosponsoredLegisla
           - The date of the latest action taken on the bill or resolution.
         - `<text>` (e.g., Referred to the Committee on Health, Education, Labor, and Pensions. (text: CR S3547-3548))
           - The text of the latest action taken on the bill or resolution.
-    - `<url>` (e.g., https://api.congress.gov/v3/bill/117/sres/714)
+    - `<url>` (e.g., <https://api.congress.gov/v3/bill/117/sres/714>)
       - A referrer URL to the bill item in the API. Documentation for the bill endpoint is [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).

--- a/Documentation/NominationEndpoint.md
+++ b/Documentation/NominationEndpoint.md
@@ -1,12 +1,20 @@
 # Nomination endpoint
+
 ## Coverage
+
 Coverage information for nominations data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about nominations data at [About Nominations by the U.S. President](https://www.congress.gov/help/nominations) on Congress.gov.
+
 ## OpenAPI Specification
-View OpenAPI Specification on the nomination API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/nomination/nomination_list). 
+
+View OpenAPI Specification on the nomination API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/nomination/nomination_list).
+
 ## Elements and Descriptions
+
 The section below details available element names, their descriptions, and possible values.
+
 ### List Level
-Note that nomination items at the list level can be filtered down by congress (e.g. 117) - https://api.congress.gov/v3/nomination/117/?api_key=.
+
+Note that nomination items at the list level can be filtered down by congress (e.g. 117) - <https://api.congress.gov/v3/nomination/117/?api_key>=.
 
 `<api-root>`
 
@@ -15,20 +23,21 @@ The `<api-root>` is only present in the XML format.
 `<nominations>`
 
 Parent container for nominations. A `<nominations>` element may include the following children:
+
 - `<item>`
   - Container for a nomination. An `<item>` element is repeatable and may include the following children:
     - `<congress>` (e.g. 117)
       - The congress during which the nomination was received.
       - View the [field value list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-     - `<number>` (e.g. 1064)
-       - The assigned nomination number.
-       - Read more about nomination numbering at [About Nominations by the U.S. President](https://www.congress.gov/help/nominations) on Congress.gov.
-     - `<partNumber>`
-       - The part number for the nomination. Nominations with multiple nominees may be partitioned if the nominees follow different confirmation paths.
-     - `<citation>` (e.g. PN1064)
-       - The citation identifying the nomination. PN indicates "Presidential Nomination" and the digits that follow are the nomination's assigned number. If the nomination was partitioned, the citation will include a dash and the part number (e.g. PN78-4).
-     - `<description>` (e.g. Lisette Nieves, of New York, to be a Member of the Board of Directors of the Corporation for National and Community Service for a term expiring October 6, 2027. (Reappointment))
-       - The description of the nomination. 
+    - `<number>` (e.g. 1064)
+      - The assigned nomination number.
+      - Read more about nomination numbering at [About Nominations by the U.S. President](https://www.congress.gov/help/nominations) on Congress.gov.
+    - `<partNumber>`
+      - The part number for the nomination. Nominations with multiple nominees may be partitioned if the nominees follow different confirmation paths.
+    - `<citation>` (e.g. PN1064)
+      - The citation identifying the nomination. PN indicates "Presidential Nomination" and the digits that follow are the nomination's assigned number. If the nomination was partitioned, the citation will include a dash and the part number (e.g. PN78-4).
+    - `<description>` (e.g. Lisette Nieves, of New York, to be a Member of the Board of Directors of the Corporation for National and Community Service for a term expiring October 6, 2027. (Reappointment))
+      - The description of the nomination.
     - `<receivedDate>` (e.g. 2021-09-13)
       - The date the nomination was received from the President.
     - `<nominationType>`
@@ -39,19 +48,21 @@ Parent container for nominations. A `<nominations>` element may include the foll
         - `<isMilitary>` (e.g. False)
           - Flag indicating whether the nomination is for a military nomination.
           - Possible values are "True" or "False".
-     - `<latestAction>` 
-        - Container for the latest action taken on the nomination. A `<latestAction>` element may include the following children:
-          - `<actionDate>` (e.g., 2022-07-21)
-            - The date of the latest action taken on the nomination.
-          - `<text>` (e.g., Confirmed by the Senate by Voice Vote.)
-            - The text of the latest action taken on the nomination. 
-     - `<updateDate>` (e.g. 2022-07-22 04:24:15+00:00)
-        - The date of update in Congress.gov.
-     - `<url>` (e.g. https://api.congress.gov/v3/nomination/117/1064)
-        - A referrer URL to the nomination item in the API.
-     - `<organization>` (e.g., Corporation for National and Community Service)
-        - The name of the organization for which the nomination was submitted.
+    - `<latestAction>`
+      - Container for the latest action taken on the nomination. A `<latestAction>` element may include the following children:
+        - `<actionDate>` (e.g., 2022-07-21)
+          - The date of the latest action taken on the nomination.
+        - `<text>` (e.g., Confirmed by the Senate by Voice Vote.)
+          - The text of the latest action taken on the nomination.
+    - `<updateDate>` (e.g. 2022-07-22 04:24:15+00:00)
+      - The date of update in Congress.gov.
+    - `<url>` (e.g. <https://api.congress.gov/v3/nomination/117/1064>)
+      - A referrer URL to the nomination item in the API.
+    - `<organization>` (e.g., Corporation for National and Community Service)
+      - The name of the organization for which the nomination was submitted.
+
 ### Item Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -59,6 +70,7 @@ The `<api-root>` is only present in the XML format.
 `<nomination>`
 
 Parent container for the nomination. A `<nomination>` element may contain the following children:
+
 - `<congress>` (e.g. 117)
   - The congress during which the nomination was received.
   - View the [field value list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
@@ -84,9 +96,9 @@ Parent container for the nomination. A `<nomination>` element may contain the fo
   - Executive calendar number information for the nomination.
 - `<authorityDate>` (e.g. 2022-07-21)
   - The date when the Senate granted authority to the Secretary of the Senate to receive nominations during periods of recess or adjournment.
-- `<nominees>` 
+- `<nominees>`
   - Container for nominee position data. A `<nominees>` element may include the following children:
-    - `<item>` 
+    - `<item>`
       - Container for a nominee position. An `<item>` element is repeatable and may include the following children:
         - `<ordinal>` (e.g. 1)
           - Ordinal used for the display order of nominees.
@@ -98,16 +110,16 @@ Parent container for the nomination. A `<nomination>` element may contain the fo
           - The title of the position for which the nominee has been nominated.
         - `<division>`
           - The name of the division within the organization for which the nominee has been nominated.
-        - `<url>` (e.g. https://api.congress.gov/v3/nomination/117/1064/1)
+        - `<url>` (e.g. <https://api.congress.gov/v3/nomination/117/1064/1>)
           - A referrer URL to the nominee position level of the nomination API. Click [here](#nominees-level) for more information about the nominee position level.
           - Note that if there are nominees for multiple positions within a nomination, there will be multiple referrer URLs to those nominee position levels. The numbering for the referrer URLs will be sequential (e.g. 1, 2, etc.).
         - `<nomineeCount>` (e.g. 1)
           - The count of nominees for a position.
-- `<committees>` 
+- `<committees>`
   - Container for committees or subcommittees with activity associated with the nomination. Read more [About Committees and Committee Materials](https://www.congress.gov/help/committee-materials) on Congress.gov.
-    - `<count>` 
+    - `<count>`
       - The number of committees with activity associated with the nomination.
-    - `<url>` 
+    - `<url>`
       - A referrer URL to the committees level of the nomination API. Click [here](#committees-level) for more information about the committees level.
 - `<latestAction>`
   - Container for the latest action taken by the Senate or the President on the nomination. A `<latestAction>` element may include the following children:
@@ -115,53 +127,57 @@ Parent container for the nomination. A `<nomination>` element may contain the fo
       - The date of the latest action taken on the nomination.
     - `<text>` (e.g. Confirmed by the Senate by Voice Vote)
       - The text of the latest action taken on the nomination.
-- `<actions>` 
+- `<actions>`
   - Container for actions on the nomination. An `<actions>` element may include the following children:
     - `<count>` (e.g. 6)
       - The number of actions on the nomination. The `<count>` may include actions from the Senate and the President.
-     - `<url>` (e.g. https://api.congress.gov/v3/nomination/117/1064/actions)
-       - A referrer URL to the actions level of the nomination API. Click [here](#actions-level) for more information about the actions level. 
+    - `<url>` (e.g. <https://api.congress.gov/v3/nomination/117/1064/actions>)
+      - A referrer URL to the actions level of the nomination API. Click [here](#actions-level) for more information about the actions level.
 - `<hearings>`
-  - Container for all printed hearings associated with the nomination. A `<hearings>` element may include the following children (the below data is from https://api.congress.gov/v3/nomination/116/389):
+  - Container for all printed hearings associated with the nomination. A `<hearings>` element may include the following children (the below data is from <https://api.congress.gov/v3/nomination/116/389>):
     - `<count>` (e.g. 1)
       - The number of printed hearings associated with the nomination.
-    -  `<url>` (e.g. https://api.congress.gov/v3/nomination/116/389/hearings)
-       - A referrer URL to the printed hearings level of the nomination API. Click [here](#hearings-level) for more information about the printed hearings level.
+    - `<url>` (e.g. <https://api.congress.gov/v3/nomination/116/389/hearings>)
+      - A referrer URL to the printed hearings level of the nomination API. Click [here](#hearings-level) for more information about the printed hearings level.
 - `<updateDate>` (e.g. 2022-07-22 04:25:15+00:00)
   - The date of update in Congress.gov.
+
 ### Nominees Level
-`<api-root>` 
+
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
 `<nominees>`
 
 Parent container for nominees associated with the nomination. A `<nominees>` element may include the following children:
+
 - `<item>`
   - Container for a nominee associated with the nomination. An `<item>` element is repeatable and may include the following children:
     - `<ordinal>` (e.g. 1)
       - Ordinal used for the display order of nominees.
     - `<lastName>` (e.g. Nieves)
       - Last name of a nominee.
-      - This element may be populated with a string (the letter 'D' followed by a sequence of numbers)  like 'D016128'. That string is an identification number used for classified nominees. 
-     - `<firstName>` (e.g. Lisette)
-       - The first name of a nominee.
-     - `<middleName>`
-       - The middle name of a nominee.
-     - `<prefix>`
-       - The name prefix for a nominee. This may be a military title, like 'Col.'
-     - `<suffix>`
-       - The name suffix for a nominee. This may suffixes like 'Jr.'
-     - `<state>` (e.g. NY)
-       - The two-digit postal code abbreviation for the nominee. 
-     - `<effectiveDate>`
-       - The date when the appointment will become effective. 
-     - `<predecessorName>`
-       - The name of the person who previously held the position to which the nominee has been nominated.
-     - `<corpsCode>`
-       - The corps code assigned by the White House to identify Corps.
+      - This element may be populated with a string (the letter 'D' followed by a sequence of numbers)  like 'D016128'. That string is an identification number used for classified nominees.
+    - `<firstName>` (e.g. Lisette)
+      - The first name of a nominee.
+    - `<middleName>`
+      - The middle name of a nominee.
+    - `<prefix>`
+      - The name prefix for a nominee. This may be a military title, like 'Col.'
+    - `<suffix>`
+      - The name suffix for a nominee. This may suffixes like 'Jr.'
+    - `<state>` (e.g. NY)
+      - The two-digit postal code abbreviation for the nominee.
+    - `<effectiveDate>`
+      - The date when the appointment will become effective.
+    - `<predecessorName>`
+      - The name of the person who previously held the position to which the nominee has been nominated.
+    - `<corpsCode>`
+      - The corps code assigned by the White House to identify Corps.
 
 ### Committees Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -169,9 +185,10 @@ The `<api-root>` is only present in the XML format.
 `<committees>`
 
 Parent container for committees with activity associated with the nomination. A list of committees with an association to data on Congress.gov is available at the [Committee Name History](https://www.congress.gov/help/committee-name-history) page on Congress.gov. A list of current committees is available at [Committees of the U.S. Congress](https://www.congress.gov/committees) on Congress.gov. A `<committees>` element may include the following children:
+
 - `<item>`
-  - Container for a committee with activity associated with the nomination. An `<item>` element is repeatable and may include the following children (the below data is from https://api.congress.gov/v3/nomination/117/1520/committees):
-    - `<url>` (e.g. https://api.congress.gov/v3/committee/house/sscm00)
+  - Container for a committee with activity associated with the nomination. An `<item>` element is repeatable and may include the following children (the below data is from <https://api.congress.gov/v3/nomination/117/1520/committees>):
+    - `<url>` (e.g. <https://api.congress.gov/v3/committee/house/sscm00>)
       - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
     - `<systemCode>` (e.g. sscm00)
       - Unique ID value for the committee.
@@ -183,17 +200,19 @@ Parent container for committees with activity associated with the nomination. A 
       - The type or status of the committee.
       - Possible values are "Standing", "Select", and "Other".
     - `<subcommittees>`
-      - Container for subcommittees with activity associated with the nomination. 
+      - Container for subcommittees with activity associated with the nomination.
     - `<activities>`
       - Container for committee or subcommittee activities associated with the nomination. An `<activities>` element may include the following children:
         - `<item>`
           - Container for a committee or subcommittee activity. An `<item>` element is repeatable and may include the following children:
             - `<name>`
               - The name of the committee or subcommittee activity.
-              - Possible values are "Referred to", "Discharged from", "Re-Referred to", "Re-Committed to", and "Reported by". 
+              - Possible values are "Referred to", "Discharged from", "Re-Referred to", "Re-Committed to", and "Reported by".
             - `<date>` (e.g. 2022-01-20T103:53:52Z)
               - The date of the committee or subcommittee activity.
+
 ### Actions Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
@@ -201,22 +220,23 @@ The `<api-root>` is only present in the XML format.
 `<actions>`
 
 Parent container for all actions taken on the nomination. Actions may come from the Senate or the President. An `<actions>` element may include the following children:
-- `<item>` 
+
+- `<item>`
   - Container for an action taken on the nomination. An `<item>` element is repeatable and may include the following children:
     - `<actionDate>`(e.g. 2022-07-21)
       - The date of action taken on the nomination.
     - `<text>` (e.g. Confirmed by the Senate by Voice Vote.)
       - The text of the action taken on the nomination.
     - `<type>` (e.g. Floor)
-      -  A short name representing stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent Senate processes.
-      -  Possible values are "IntroReferral", "Committee", "Calendars", and "Floor".
+      - A short name representing stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent Senate processes.
+      - Possible values are "IntroReferral", "Committee", "Calendars", and "Floor".
     - `<actionCode>` (e.g. S05310)
       - A Senate-provided code associated with the action taken on the nomination.
     - `<committees>`
       - Container for committees associated with the action. A `<committees>` element may include the following children:
         - `<item>`
           - Container for a committee associated with the action. An `<item>` element is repeatable and may include the following children:
-            - `<url>` 
+            - `<url>`
               - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
             - `<systemCode>`
               - Unique ID value for the committee.
@@ -224,13 +244,15 @@ Parent container for all actions taken on the nomination. Actions may come from 
               - The name of committee.
 
 ### Hearings Level
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
 `<hearings>`
 
-Parent container for printed hearings associated with the nomination. A `<hearings>` element may include the following children (the below data is from https://api.congress.gov/v3/nomination/116/389/hearings):
+Parent container for printed hearings associated with the nomination. A `<hearings>` element may include the following children (the below data is from <https://api.congress.gov/v3/nomination/116/389/hearings>):
+
 - `<item>`
   - Container for a printed hearing on the nomination. An `<item>` element is repeatable and may include the following children:
     - `<chamber>` (e.g. Senate)
@@ -247,4 +269,4 @@ Parent container for printed hearings associated with the nomination. A `<hearin
       - If errata, the printed hearing's errata number.
       - Read more [about errata](https://www.congress.gov/help/legislative-glossary#glossary_errata) on Congress.gov.
     - `<date>` (e.g. 2019-06-05)
-      - The date when the hearing took place. 
+      - The date when the hearing took place.

--- a/Documentation/SenateCommunicationEndpoint.md
+++ b/Documentation/SenateCommunicationEndpoint.md
@@ -1,20 +1,29 @@
 # Senate communication endpoint
-## Coverage
-Coverage information for Senate communications data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about Senate communications data at [About Senate Executive and Other Communications](https://www.congress.gov/help/senate-communications) on Congress.gov.
-## OpenAPI Specification
-View OpenAPI Specification on the Senate communications API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/senate-communication/senate_communication). 
-## Elements and Descriptions
-The section below details available element names, their description, and possible values.
-### List Level
-Note that Senate communication items at the list level can be filtered down by congress (e.g. 117) and by communication type (e.g. ec) - https://api.congress.gov/v3/senate-communication/117/ec?api_key=.
 
-`<api-root>` 
+## Coverage
+
+Coverage information for Senate communications data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about Senate communications data at [About Senate Executive and Other Communications](https://www.congress.gov/help/senate-communications) on Congress.gov.
+
+## OpenAPI Specification
+
+View OpenAPI Specification on the Senate communications API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/senate-communication/senate_communication).
+
+## Elements and Descriptions
+
+The section below details available element names, their description, and possible values.
+
+### List Level
+
+Note that Senate communication items at the list level can be filtered down by congress (e.g. 117) and by communication type (e.g. ec) - <https://api.congress.gov/v3/senate-communication/117/ec?api_key>=.
+
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
-`<senateCommunications>` 
+`<senateCommunications>`
 
 Parent container for Senate communications. A `<senateCommunications>` element may include the following children:
+
 - `<item>`
   - Container for a Senate communication item. An `<item>` element is repeatable and may include the following children:
     - `<chamber>` (e.g. Senate)
@@ -32,17 +41,19 @@ Parent container for Senate communications. A `<senateCommunications>` element m
     - `<congress>` (e.g. 117)
       - The congress during which the communication was received.
       - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-    - `<url>` (e.g. https://api.congress.gov/v3/senate-communication/117/ec/2561)
+    - `<url>` (e.g. <https://api.congress.gov/v3/senate-communication/117/ec/2561>)
       - A referrer URL to the communication item in the API.
 
 ## Item Level
-`<api-root>` 
+
+`<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
 `<senate-communication>`
 
 Parent container for a Senate communication item. A `<senate-communication>` element may include the following children:
+
 - `<chamber>` (e.g. Senate)
   - The chamber where the communication was received. This value will always be set to "Senate".
 - `<number>` (e.g. 2561)
@@ -61,7 +72,7 @@ Parent container for a Senate communication item. A `<senate-communication>` ele
 - `<abstract>` (e.g. A communication from the Board Chairman and Chief Executive Officer, Farm Credit Administration, transmitting, pursuant to law, the Administration's annual report for calendar year 2021; to the Committee on Agriculture, Nutrition, and Forestry.)
   - The abstract text for the communication.
 - `<congressionalRecordDate>` (e.g. 2021-11-03)
-  - The date the communication was published in the Congressional Record. 
+  - The date the communication was published in the Congressional Record.
 - `<committees>`
   - Container for committees associated with the communication. A `<committees>` element may include the following children:
     - `<item>`
@@ -70,5 +81,5 @@ Parent container for a Senate communication item. A `<senate-communication>` ele
           - The name of the committee.
         - `<referralDate>` (e.g. 2021-11-03)
           - The date the communication was referred to the committee.
-        - `<url>` (e.g. https://api.congress.gov/v3/committee/senate/ssaf00)
+        - `<url>` (e.g. <https://api.congress.gov/v3/committee/senate/ssaf00>)
           - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).

--- a/Documentation/SummariesEndpoint.md
+++ b/Documentation/SummariesEndpoint.md
@@ -1,65 +1,76 @@
 # Summaries endpoint
+
 ## Coverage
-Coverage information for bill summaries data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). By default, only bill summaries published in the last day are available from this endpoint unless "fromDateTime" and/or "toDateTime" parameters are added to the API request (read more about those parameters in the OpenAPI Specification, linked below); however, all bill summaries published for bills available on Congress.gov can be found at the [bill endpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md#summaries-level). 
+
+Coverage information for bill summaries data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). By default, only bill summaries published in the last day are available from this endpoint unless "fromDateTime" and/or "toDateTime" parameters are added to the API request (read more about those parameters in the OpenAPI Specification, linked below); however, all bill summaries published for bills available on Congress.gov can be found at the [bill endpoint](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md#summaries-level).
+
 ## OpenAPI Specification
+
 View OpenAPI Specification on the summaries API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/summaries/bill_summaries_all).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
-Note that bill summary items at the list level can be filtered down by congress (e.g., 117) and by bill type (e.g., hr) - https://api.congress.gov/v3/summaries/117/hr?api_key=.
+
+Note that bill summary items at the list level can be filtered down by congress (e.g., 117) and by bill type (e.g., hr) - <https://api.congress.gov/v3/summaries/117/hr?api_key>=.
 
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<summaries>`
 
  Parent container for bill summaries. A `<summaries>` element may include the following children:
- - `<summary>`
-   - Container for an individual bill summary. A `<summary>` element is repeatable and may include the following children: 
-     - `<bill>`
-     	- Container for the associated bill to the summary. A `<bill>` element may include the following children:   
-     		- `<congress>` (e.g., 117)
-     			- The congress during which a bill or resolution was introduced or submitted.
-     			- View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-     		- `<type>` (e.g., HR)
-     			- The type of bill or resolution.
-     			- Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
-     		- `<originChamber>` (e.g., House)
-     			- The chamber of origin where a bill or resolution was introduced or submitted.
-     			- Possible values are "House" and "Senate".
-     		- `<originChamberCode>` (e.g., H)
-     			- The code for the chamber of origin where the bill or resolution was introduced or submitted.
-     			- Possible values are "H" and "S".
-     		- `<number>` (e.g., 8432)
-     			- The assigned bill or resolution number.
-     		- `<url>` (e.g., https://api.congress.gov/v3/bill/117/hr/8432) 
-     			- A referrer URL to the bill or resolution item in the API. Documentation for the bill endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
-		 - `<title>` (e.g., Beagle Brigade Act of 2022)
-		 	- The display title for the bill or resolution on Congress.gov.
-		 - `<updateDateIncludingText>` (e.g., 2022-09-29T07:15:39Z)
-		 	- The date of update for the bill on Congres.gov, which includes updates to the bill's text.
-	 - `<text>` (e.g., `<![CDATA[ <p><strong>Beagle Brigade Act of 2022</strong></p> <p>This bill provides statutory authority for the National Detector Dog Training Center that is operated by the Animal and Plant Health Inspection Service of the Department of Agriculture. The center trains dogs to inspect passenger baggage, cargo, mailed packages, and vehicles to detect foreign pests and diseases that threaten domestic agriculture and natural resources.</p> ]]>`>
-	   - The text of the bill summary.
-		- Note that the bill summary text is encased in CDATA and contains HTML codes. The HTML codes may not be valid (see [#2](https://github.com/LibraryOfCongress/api.congress.gov/issues/2)); efforts are underway to improve the validity of the HTML codes.
-	 - `<actionDate>` (e.g., 2022-05-16)
-	   - The date of the action associated with the bill summary. 
-	 - `<updateDate>` (e.g., 2022-08-18T17:00:44Z)
-	   - The date of update on Congress.gov. 
-	 - `<currentChamber>` (e.g., House)
-	   - The chamber that took the action associated with the bill summary.
-	   - Possible values are "House" and "Senate".
-	 - `<currentChamberCode>` (e.g., H)
-	   - The code for the chamber that took the action associated with the bill summary. 
-	   - Possible values are "H" and "S".
-	 - `<actionDesc>` (e.g., Introduced in House)
-	   - The description of the action associated with the bill summary. 
-	 - `<versionCode>` (e.g., 00)
-	   - The internal code used by CRS to tag its bill summaries according to the action associated with the bill summary.
-		- Click [here](#bill-summary-version-codes-action-descriptions-and-chamber) for a list of codes. Note that the version codes used have varied over time.  
-	 - `<lastSummaryUpdateDate>` (e.g., 2022-08-18T16:46:01Z)
-		- The date the bill summary was last updated. This date also reflects the date and time when a bill summary is re-published.
-##### Bill summary version codes, action descriptions, and chamber
+
+- `<summary>`
+  - Container for an individual bill summary. A `<summary>` element is repeatable and may include the following children:
+    - `<bill>`
+      - Container for the associated bill to the summary. A `<bill>` element may include the following children:
+        - `<congress>` (e.g., 117)
+          - The congress during which a bill or resolution was introduced or submitted.
+          - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
+        - `<type>` (e.g., HR)
+          - The type of bill or resolution.
+          - Possible values are "HR", "S", "HJRES", "SJRES", "HCONRES", "SCONRES", "HRES", and "SRES".
+        - `<originChamber>` (e.g., House)
+          - The chamber of origin where a bill or resolution was introduced or submitted.
+          - Possible values are "House" and "Senate".
+        - `<originChamberCode>` (e.g., H)
+          - The code for the chamber of origin where the bill or resolution was introduced or submitted.
+          - Possible values are "H" and "S".
+        - `<number>` (e.g., 8432)
+          - The assigned bill or resolution number.
+        - `<url>` (e.g., <https://api.congress.gov/v3/bill/117/hr/8432>)
+          - A referrer URL to the bill or resolution item in the API. Documentation for the bill endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/BillEndpoint.md).
+        - `<title>` (e.g., Beagle Brigade Act of 2022)
+          - The display title for the bill or resolution on Congress.gov.
+        - `<updateDateIncludingText>` (e.g., 2022-09-29T07:15:39Z)
+          - The date of update for the bill on Congres.gov, which includes updates to the bill's text.
+    - `<text>` (e.g., `<![CDATA[ <p><strong>Beagle Brigade Act of 2022</strong></p> <p>This bill provides statutory authority for the National Detector Dog Training Center that is operated by the Animal and Plant Health Inspection Service of the Department of Agriculture. The center trains dogs to inspect passenger baggage, cargo, mailed packages, and vehicles to detect foreign pests and diseases that threaten domestic agriculture and natural resources.</p> ]]>`>
+      - The text of the bill summary.
+      - Note that the bill summary text is encased in CDATA and contains HTML codes. The HTML codes may not be valid (see [#2](https://github.com/LibraryOfCongress/api.congress.gov/issues/2)); efforts are underway to improve the validity of the HTML codes.
+    - `<actionDate>` (e.g., 2022-05-16)
+      - The date of the action associated with the bill summary.
+    - `<updateDate>` (e.g., 2022-08-18T17:00:44Z)
+      - The date of update on Congress.gov.
+    - `<currentChamber>` (e.g., House)
+      - The chamber that took the action associated with the bill summary.
+      - Possible values are "House" and "Senate".
+    - `<currentChamberCode>` (e.g., H)
+      - The code for the chamber that took the action associated with the bill summary.
+      - Possible values are "H" and "S".
+    - `<actionDesc>` (e.g., Introduced in House)
+      - The description of the action associated with the bill summary.
+    - `<versionCode>` (e.g., 00)
+      - The internal code used by CRS to tag its bill summaries according to the action associated with the bill summary.
+      - Click [here](#bill-summary-version-codes-action-descriptions-and-chamber) for a list of codes. Note that the version codes used have varied over time.  
+    - `<lastSummaryUpdateDate>` (e.g., 2022-08-18T16:46:01Z)
+      - The date the bill summary was last updated. This date also reflects the date and time when a bill summary is re-published.
+
+#### Bill summary version codes, action descriptions, and chamber
+
 | versionCode | actionDesc | chamber |
 | ----------- | ---------- | ------- |
 | 00 | Introduced in House | House |

--- a/Documentation/TreatyEndpoint.md
+++ b/Documentation/TreatyEndpoint.md
@@ -1,167 +1,180 @@
 # Treaty endpoint
+
 ## Coverage
+
 Coverage information for treaty data in the API can be found at [Coverage Dates for Congress.gov Collections](https://www.congress.gov/help/coverage-dates). Read more about treaty data at [About Treaty Documents](https://www.congress.gov/help/treaty-documents) on Congress.gov.
+
 ## OpenAPI Specification
+
 View OpenAPI Specification on the treaty API, supported endpoints, and available parameters at [https://api.congress.gov](https://api.congress.gov/#/treaty/treaty_list).
+
 ## Elements and Descriptions
+
 The section below details available element names, their description, and possible values.
+
 ### List Level
-Note that treaty document items at the list level can be filtered down by congress of submission (e.g. 117) – https://api.congress.gov/v3/treaty?api_key=.
+
+Note that treaty document items at the list level can be filtered down by congress of submission (e.g. 117) – <https://api.congress.gov/v3/treaty?api_key>=.
 
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<treaties>`  
 
 Parent container for treaties. A `<treaties>` element may include the following children:
- - `<item>`
-   - Container for an individual treaty. An `<item>` element is repeatable and may include the following children: 
-     - `<congress>` (e.g., 117)
-		- The congress during which the treaty was submitted. 
-		- Unlike bills and resolutions, treaties remain active in a congress until they are ratified or returned to the President.
-		- View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
-	 - `<endCongressId>` (e.g., 117)
-		- The congress during which the treaty was ratified or returned to the President. 
-	 - `<treatyNum>` (e.g., 3)
-		- The assigned treaty number.
-	 - `<treatySuffix>`
-		- The treaty part, if the treaty was partitioned.
-		- Possible values include "A", "B", "C", etc.
-	 - `<transmittedDate>` (e.g., 2022-07-11T00:00:00Z)
-	   - The date the treaty was transmitted to the Senate.
-	 - `<resolutionText>` (e.g., `<![CDATA[<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta name="meta:creation-date" content="2022/08/03 18:28:08" /><meta name="dc:title" content="[117] TreatyRes. 6 for TreatyDoc. 117 - 3" /><meta name="Creation-Date" content="2022/08/03 18:28:08" /><meta name="dcterms:created" content="2022/08/03 18:28:08" /><meta name="Content-Type" content="application/rtf" /><title>[117] TreatyRes. 6 for TreatyDoc. 117 - 3</title></head><body><p>As approved by the Senate: </p><p><i>Resolved (two-thirds of the Senators present concurring therein),</i></p><p></p><p><b>SECTION 1. SENATE ADVICE AND CONSENT SUBJECT TO DECLARATIONS AND CONDITIONS.</b></p><p></p><p>The Senate advises and consents to the ratification of the Protocols to the North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden, which were signed on July 5, 2022, by the United States of America and other parties to the North Atlantic Treaty of 1949 (Treaty Doc. 117-3), subject to the declarations of section 2 and the condition of section 3.</p><p><b>SEC. 2. DECLARATIONS.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following declarations:</p><p>(1)Reaffirmation That United States Membership in NATO Remains a Vital National Security Interest of the United States.- The Senate declares that-</p><p>(A)for more than 70 years the North Atlantic Treaty Organization (NATO) has served as the preeminent organization to defend the countries in the North Atlantic area against all external threats;</p><p>(B)through common action, the established democracies of North America and Europe that were joined in NATO persevered and prevailed in the task of ensuring the survival of democratic government in Europe and North America throughout the Cold War;</p><p>(C)NATO enhances the security of the United States by embedding European states in a process of cooperative security planning and by ensuring an ongoing and direct leadership role for the United States in European security affairs;</p><p>(D)the responsibility and financial burden of defending the democracies of Europe and North America can be more equitably shared through an alliance in which specific obligations and force goals are met by its members;</p><p>(E)the security and prosperity of the United States is enhanced by NATO's collective defense against aggression that may threaten the security of NATO members; and</p><p>(F)United States membership in NATO remains a vital national security interest of the United States.</p><p>(2)Strategic Rationale for NATO Enlargement.- The Senate declares that-</p><p>(A)the United States and its NATO allies face continued threats to their stability and territorial integrity;</p><p>(B)an attack against Finland or Sweden, or the destabilization of either arising from external subversion, would threaten the stability of Europe and jeopardize United States national security interests;</p><p>(C)Finland and Sweden, having established democratic governments and having demonstrated a willingness to meet the requirements of membership, including those necessary to contribute to the defense of all NATO members, are in a position to further the principles of the North Atlantic Treaty and to contribute to the security of the North Atlantic area; and</p><p>(D)extending NATO membership to Finland and Sweden will strengthen NATO, enhance stability in Europe, and advance the interests of the United States and its NATO allies.</p><p>(3)Support for NATO's Open Door Policy.- The policy of the United States is to support NATO's Open Door Policy that allows any European country to express its desire to join NATO and demonstrate its ability to meet the obligations of NATO membership.</p><p>(4)Future Consideration of Candidates for Membership in NATO.-</p><p>(A)Senate Finding.-The Senate finds that the United States will not support the accession to the North Atlantic Treaty of, or the invitation to begin accession talks with, any European state (other than Finland and Sweden), unless-</p><p>(i)the President consults with the Senate consistent with Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties); and</p><p>(ii)the prospective NATO member can fulfill all of the obligations and responsibilities of membership, and the inclusion of such state in NATO would serve the overall political and strategic interests of NATO and the United States.</p><p>(B)Requirement for Consensus and Ratification.-The Senate declares that no action or agreement other than a consensus decision by the full membership of NATO, approved by the national procedures of each NATO member, including, in the case of the United States, the requirements of Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties), will constitute a commitment to collective defense and consultations pursuant to Articles 4 and 5 of the North Atlantic Treaty.</p><p>(5)Influence of Non-NATO Members on NATO Decisions.- The Senate declares that any country that is not a member of NATO shall have no impact on decisions related to NATO enlargement.</p><p>(6)Support for 2014 Wales Summit Defense Spending Benchmark.--The Senate declares that all NATO members should spend a minimum of 2 percent of their Gross Domestic Product (GDP) on defense and 20 percent of their defense budgets on major equipment, including research and development, by 2024, as outlined in the 2014 Wales Summit Declaration.</p><p><b>SEC. 3. CONDITION.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following conditions</p><p>(1)Presidential Certification.-Prior to the deposit of the instrument of ratification, the President shall certify to the Senate as follows:</p><p>(A)The inclusion of Finland and Sweden in NATO will not have the effect of increasing the overall percentage share of the United States in the common budgets of NATO.</p><p>(B)The inclusion of Finland and Sweden in NATO does not detract from the ability of the United States to meet or to fund its military requirements outside the North Atlantic area.</p><p><b>SEC. 4. DEFINITIONS.</b></p><p></p><p>In this resolution:</p><p>(1)NATO Members.-The term &ldquo;NATO members&rdquo; means all countries that are parties to the North Atlantic Treaty.</p><p>(2)Non-NATO Members.-The term &ldquo;non-NATO members&rdquo; means all countries that are not parties to the North Atlantic Treaty.</p><p>(3)North Atlantic Area.-The term &ldquo;North Atlantic Area&rdquo; means the area covered by Article 6 of the North Atlantic Treaty, as applied by the North Atlantic Council.</p><p>(4)North Atlantic Treaty.-The term &ldquo;North Atlantic Treaty&rdquo; means the North Atlantic Treaty, signed at Washington April 4, 1949 (63 Stat. 2241; TIAS 1964), as amended.</p><p>(5)United States Instrument of Ratification.-The term &ldquo;United States instrument of ratification&rdquo; means the instrument of ratification of the United States of the Protocols to the</p><p>North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden.</p></body></html>]]>`)
-		- The text of the resolution of ratification.
-		- Note that the text is encased in CDATA and includes HTML codes.
-	 - `<treatySubject>` (e.g., International Law and Organization)
-	   - The assigned topic of the treaty.  
-	 - `<updateDate>` (e.g., 2022-08-04T02:46:11Z)
-	   - The date of update on Congress.gov.
-	 - `<parts>`
-	    - Container for treaty part information. A `<parts>` element may include the following children (the below data is taken from https://api.congress.gov/v3/treaty/114/13):
-	         - `<count>` (e.g., 2)
-	              - The number of treaty parts.
-	         - `<urls>`
-	              - Container for the referrer URLs to the treaty part items in the API. A `<urls>` element may include the following children:
-	                   - `<item>` (e.g., https://api.congress.gov/v3/treaty/114/13/B)
-	                       - A referrer URL to the treaty part item in the API.
-	 - `<url>` (e.g., http://https://api.congress.gov/v3/treaty/117/3)
-	     - A referrer URL to the treaty item on the API.
-	  
+
+- `<item>`
+  - Container for an individual treaty. An `<item>` element is repeatable and may include the following children:
+    - `<congress>` (e.g., 117)
+      - The congress during which the treaty was submitted.
+      - Unlike bills and resolutions, treaties remain active in a congress until they are ratified or returned to the President.
+      - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
+    - `<endCongressId>` (e.g., 117)
+      - The congress during which the treaty was ratified or returned to the President.
+    - `<treatyNum>` (e.g., 3)
+      - The assigned treaty number.
+    - `<treatySuffix>`
+      - The treaty part, if the treaty was partitioned.
+      - Possible values include "A", "B", "C", etc.
+    - `<transmittedDate>` (e.g., 2022-07-11T00:00:00Z)
+      - The date the treaty was transmitted to the Senate.
+    - `<resolutionText>` (e.g., `<![CDATA[<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta name="meta:creation-date" content="2022/08/03 18:28:08" /><meta name="dc:title" content="[117] TreatyRes. 6 for TreatyDoc. 117 - 3" /><meta name="Creation-Date" content="2022/08/03 18:28:08" /><meta name="dcterms:created" content="2022/08/03 18:28:08" /><meta name="Content-Type" content="application/rtf" /><title>[117] TreatyRes. 6 for TreatyDoc. 117 - 3</title></head><body><p>As approved by the Senate: </p><p><i>Resolved (two-thirds of the Senators present concurring therein),</i></p><p></p><p><b>SECTION 1. SENATE ADVICE AND CONSENT SUBJECT TO DECLARATIONS AND CONDITIONS.</b></p><p></p><p>The Senate advises and consents to the ratification of the Protocols to the North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden, which were signed on July 5, 2022, by the United States of America and other parties to the North Atlantic Treaty of 1949 (Treaty Doc. 117-3), subject to the declarations of section 2 and the condition of section 3.</p><p><b>SEC. 2. DECLARATIONS.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following declarations:</p><p>(1)Reaffirmation That United States Membership in NATO Remains a Vital National Security Interest of the United States.- The Senate declares that-</p><p>(A)for more than 70 years the North Atlantic Treaty Organization (NATO) has served as the preeminent organization to defend the countries in the North Atlantic area against all external threats;</p><p>(B)through common action, the established democracies of North America and Europe that were joined in NATO persevered and prevailed in the task of ensuring the survival of democratic government in Europe and North America throughout the Cold War;</p><p>(C)NATO enhances the security of the United States by embedding European states in a process of cooperative security planning and by ensuring an ongoing and direct leadership role for the United States in European security affairs;</p><p>(D)the responsibility and financial burden of defending the democracies of Europe and North America can be more equitably shared through an alliance in which specific obligations and force goals are met by its members;</p><p>(E)the security and prosperity of the United States is enhanced by NATO's collective defense against aggression that may threaten the security of NATO members; and</p><p>(F)United States membership in NATO remains a vital national security interest of the United States.</p><p>(2)Strategic Rationale for NATO Enlargement.- The Senate declares that-</p><p>(A)the United States and its NATO allies face continued threats to their stability and territorial integrity;</p><p>(B)an attack against Finland or Sweden, or the destabilization of either arising from external subversion, would threaten the stability of Europe and jeopardize United States national security interests;</p><p>(C)Finland and Sweden, having established democratic governments and having demonstrated a willingness to meet the requirements of membership, including those necessary to contribute to the defense of all NATO members, are in a position to further the principles of the North Atlantic Treaty and to contribute to the security of the North Atlantic area; and</p><p>(D)extending NATO membership to Finland and Sweden will strengthen NATO, enhance stability in Europe, and advance the interests of the United States and its NATO allies.</p><p>(3)Support for NATO's Open Door Policy.- The policy of the United States is to support NATO's Open Door Policy that allows any European country to express its desire to join NATO and demonstrate its ability to meet the obligations of NATO membership.</p><p>(4)Future Consideration of Candidates for Membership in NATO.-</p><p>(A)Senate Finding.-The Senate finds that the United States will not support the accession to the North Atlantic Treaty of, or the invitation to begin accession talks with, any European state (other than Finland and Sweden), unless-</p><p>(i)the President consults with the Senate consistent with Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties); and</p><p>(ii)the prospective NATO member can fulfill all of the obligations and responsibilities of membership, and the inclusion of such state in NATO would serve the overall political and strategic interests of NATO and the United States.</p><p>(B)Requirement for Consensus and Ratification.-The Senate declares that no action or agreement other than a consensus decision by the full membership of NATO, approved by the national procedures of each NATO member, including, in the case of the United States, the requirements of Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties), will constitute a commitment to collective defense and consultations pursuant to Articles 4 and 5 of the North Atlantic Treaty.</p><p>(5)Influence of Non-NATO Members on NATO Decisions.- The Senate declares that any country that is not a member of NATO shall have no impact on decisions related to NATO enlargement.</p><p>(6)Support for 2014 Wales Summit Defense Spending Benchmark.--The Senate declares that all NATO members should spend a minimum of 2 percent of their Gross Domestic Product (GDP) on defense and 20 percent of their defense budgets on major equipment, including research and development, by 2024, as outlined in the 2014 Wales Summit Declaration.</p><p><b>SEC. 3. CONDITION.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following conditions</p><p>(1)Presidential Certification.-Prior to the deposit of the instrument of ratification, the President shall certify to the Senate as follows:</p><p>(A)The inclusion of Finland and Sweden in NATO will not have the effect of increasing the overall percentage share of the United States in the common budgets of NATO.</p><p>(B)The inclusion of Finland and Sweden in NATO does not detract from the ability of the United States to meet or to fund its military requirements outside the North Atlantic area.</p><p><b>SEC. 4. DEFINITIONS.</b></p><p></p><p>In this resolution:</p><p>(1)NATO Members.-The term &ldquo;NATO members&rdquo; means all countries that are parties to the North Atlantic Treaty.</p><p>(2)Non-NATO Members.-The term &ldquo;non-NATO members&rdquo; means all countries that are not parties to the North Atlantic Treaty.</p><p>(3)North Atlantic Area.-The term &ldquo;North Atlantic Area&rdquo; means the area covered by Article 6 of the North Atlantic Treaty, as applied by the North Atlantic Council.</p><p>(4)North Atlantic Treaty.-The term &ldquo;North Atlantic Treaty&rdquo; means the North Atlantic Treaty, signed at Washington April 4, 1949 (63 Stat. 2241; TIAS 1964), as amended.</p><p>(5)United States Instrument of Ratification.-The term &ldquo;United States instrument of ratification&rdquo; means the instrument of ratification of the United States of the Protocols to the</p><p>North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden.</p></body></html>]]>`)
+      - The text of the resolution of ratification.
+      - Note that the text is encased in CDATA and includes HTML codes.
+    - `<treatySubject>` (e.g., International Law and Organization)
+      - The assigned topic of the treaty.  
+    - `<updateDate>` (e.g., 2022-08-04T02:46:11Z)
+      - The date of update on Congress.gov.
+    - `<parts>`
+      - Container for treaty part information. A `<parts>` element may include the following children (the below data is taken from <https://api.congress.gov/v3/treaty/114/13>):
+        - `<count>` (e.g., 2)
+          - The number of treaty parts.
+        - `<urls>`
+          - Container for the referrer URLs to the treaty part items in the API. A `<urls>` element may include the following children:
+            - `<item>` (e.g., <https://api.congress.gov/v3/treaty/114/13/B>)
+              - A referrer URL to the treaty part item in the API.
+    - `<url>` (e.g., <http://https://api.congress.gov/v3/treaty/117/3>)
+      - A referrer URL to the treaty item on the API.
+
 ### Item Level
 
 `<api-root>`
 
-The `<api-root>` is only present in the XML format. 
+The `<api-root>` is only present in the XML format.
 
 `<treaty>`
+
 - Parent container for an individual treaty. A `<treaty>` element may include the following children:
   - `<congress>` (e.g., 117)
-     - The congress during which the treaty was submitted.
-     - Unlike bills and resolutions, treaties remain active in a congress until they are ratified or returned to the President.
-     - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
+    - The congress during which the treaty was submitted.
+    - Unlike bills and resolutions, treaties remain active in a congress until they are ratified or returned to the President.
+    - View the [field values list of Congresses](https://www.congress.gov/help/field-values/congresses) on Congress.gov. Read more [about Congresses](https://www.congress.gov/help/legislative-glossary#glossary_congress) on Congress.gov.
   - `<endCongressId>` (e.g., 117)
-    - The congress during which the treaty was ratified or returned to the President. 
+    - The congress during which the treaty was ratified or returned to the President.
   - `<treatyNum>` (e.g., 3)
     - The assigned treaty number.
   - `<treatySuffix>`
     - The treaty part, if the treaty was partitioned.
     - Possible values include "A", "B", "C", etc.
   - `<oldTreatyNum>`
-     - The number assigned to treaties ratified prior to the 97th Congress. 
-     - To allow for searching by treaty document number on Congess.gov, old treaty numbers were converted. View the table that converts the old numbering to a new one at the [Treaty Numbers Conversion Table](https://www.congress.gov/help/treaty-documents#conversion) on Congress.gov.
-   - `<oldTreatyNumDisplayStr>`
-     - The original treaty number display string, prior to conversion, for treaties ratified prior to the 97th Congress.
-     - To allow for searching by treaty document number on Congess.gov, old treaty numbers were converted. View the table that converts the old numbering method to a new one at the [Treaty Numbers Conversion Table](https://www.congress.gov/help/treaty-documents#conversion) on Congress.gov.
-   - `<transmittedDate>` (e.g., 2022-07-11T00:00:00Z)
-     - The date the treaty was transmitted to the Senate. 
-   - `<inForceDate>`
-     - The date when the treaty agreement takes effect.
-   - `<relatedDocs>`
-     - Container for executive reports associated with the treaty. A `<relatedDocs>` element may include the following children (the data below is taken from https://api.congress.gov/v3/treaty/116/1):
-        - `<item>`
-            - Container element for individual executive reports associated with the treaty. An `<item>` element may include the following children:
-              - `<name>` (e.g., Ex. Rept. 116-5)
-		         - The citation for the associated executive report.
-              - `<url>` (e.g., https://api.congress.gov/v3/committee-report/116/ERPT/5)
-		         - A referrer URL to the executive report item in the API. Documentation on committee reports is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeReportEndpoint.md).
-    - `<resolutionText>` (e.g., `<![CDATA[<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta name="meta:creation-date" content="2022/08/03 18:28:08" /><meta name="dc:title" content="[117] TreatyRes. 6 for TreatyDoc. 117 - 3" /><meta name="Creation-Date" content="2022/08/03 18:28:08" /><meta name="dcterms:created" content="2022/08/03 18:28:08" /><meta name="Content-Type" content="application/rtf" /><title>[117] TreatyRes. 6 for TreatyDoc. 117 - 3</title></head><body><p>As approved by the Senate: </p><p><i>Resolved (two-thirds of the Senators present concurring therein),</i></p><p></p><p><b>SECTION 1. SENATE ADVICE AND CONSENT SUBJECT TO DECLARATIONS AND CONDITIONS.</b></p><p></p><p>The Senate advises and consents to the ratification of the Protocols to the North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden, which were signed on July 5, 2022, by the United States of America and other parties to the North Atlantic Treaty of 1949 (Treaty Doc. 117-3), subject to the declarations of section 2 and the condition of section 3.</p><p><b>SEC. 2. DECLARATIONS.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following declarations:</p><p>(1)Reaffirmation That United States Membership in NATO Remains a Vital National Security Interest of the United States.- The Senate declares that-</p><p>(A)for more than 70 years the North Atlantic Treaty Organization (NATO) has served as the preeminent organization to defend the countries in the North Atlantic area against all external threats;</p><p>(B)through common action, the established democracies of North America and Europe that were joined in NATO persevered and prevailed in the task of ensuring the survival of democratic government in Europe and North America throughout the Cold War;</p><p>(C)NATO enhances the security of the United States by embedding European states in a process of cooperative security planning and by ensuring an ongoing and direct leadership role for the United States in European security affairs;</p><p>(D)the responsibility and financial burden of defending the democracies of Europe and North America can be more equitably shared through an alliance in which specific obligations and force goals are met by its members;</p><p>(E)the security and prosperity of the United States is enhanced by NATO's collective defense against aggression that may threaten the security of NATO members; and</p><p>(F)United States membership in NATO remains a vital national security interest of the United States.</p><p>(2)Strategic Rationale for NATO Enlargement.- The Senate declares that-</p><p>(A)the United States and its NATO allies face continued threats to their stability and territorial integrity;</p><p>(B)an attack against Finland or Sweden, or the destabilization of either arising from external subversion, would threaten the stability of Europe and jeopardize United States national security interests;</p><p>(C)Finland and Sweden, having established democratic governments and having demonstrated a willingness to meet the requirements of membership, including those necessary to contribute to the defense of all NATO members, are in a position to further the principles of the North Atlantic Treaty and to contribute to the security of the North Atlantic area; and</p><p>(D)extending NATO membership to Finland and Sweden will strengthen NATO, enhance stability in Europe, and advance the interests of the United States and its NATO allies.</p><p>(3)Support for NATO's Open Door Policy.- The policy of the United States is to support NATO's Open Door Policy that allows any European country to express its desire to join NATO and demonstrate its ability to meet the obligations of NATO membership.</p><p>(4)Future Consideration of Candidates for Membership in NATO.-</p><p>(A)Senate Finding.-The Senate finds that the United States will not support the accession to the North Atlantic Treaty of, or the invitation to begin accession talks with, any European state (other than Finland and Sweden), unless-</p><p>(i)the President consults with the Senate consistent with Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties); and</p><p>(ii)the prospective NATO member can fulfill all of the obligations and responsibilities of membership, and the inclusion of such state in NATO would serve the overall political and strategic interests of NATO and the United States.</p><p>(B)Requirement for Consensus and Ratification.-The Senate declares that no action or agreement other than a consensus decision by the full membership of NATO, approved by the national procedures of each NATO member, including, in the case of the United States, the requirements of Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties), will constitute a commitment to collective defense and consultations pursuant to Articles 4 and 5 of the North Atlantic Treaty.</p><p>(5)Influence of Non-NATO Members on NATO Decisions.- The Senate declares that any country that is not a member of NATO shall have no impact on decisions related to NATO enlargement.</p><p>(6)Support for 2014 Wales Summit Defense Spending Benchmark.--The Senate declares that all NATO members should spend a minimum of 2 percent of their Gross Domestic Product (GDP) on defense and 20 percent of their defense budgets on major equipment, including research and development, by 2024, as outlined in the 2014 Wales Summit Declaration.</p><p><b>SEC. 3. CONDITION.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following conditions</p><p>(1)Presidential Certification.-Prior to the deposit of the instrument of ratification, the President shall certify to the Senate as follows:</p><p>(A)The inclusion of Finland and Sweden in NATO will not have the effect of increasing the overall percentage share of the United States in the common budgets of NATO.</p><p>(B)The inclusion of Finland and Sweden in NATO does not detract from the ability of the United States to meet or to fund its military requirements outside the North Atlantic area.</p><p><b>SEC. 4. DEFINITIONS.</b></p><p></p><p>In this resolution:</p><p>(1)NATO Members.-The term &ldquo;NATO members&rdquo; means all countries that are parties to the North Atlantic Treaty.</p><p>(2)Non-NATO Members.-The term &ldquo;non-NATO members&rdquo; means all countries that are not parties to the North Atlantic Treaty.</p><p>(3)North Atlantic Area.-The term &ldquo;North Atlantic Area&rdquo; means the area covered by Article 6 of the North Atlantic Treaty, as applied by the North Atlantic Council.</p><p>(4)North Atlantic Treaty.-The term &ldquo;North Atlantic Treaty&rdquo; means the North Atlantic Treaty, signed at Washington April 4, 1949 (63 Stat. 2241; TIAS 1964), as amended.</p><p>(5)United States Instrument of Ratification.-The term &ldquo;United States instrument of ratification&rdquo; means the instrument of ratification of the United States of the Protocols to the</p><p>North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden.</p></body></html>]]>`)
-      - The text of the resolution of ratification.
-      - Note that the text is encased in CDATA and includes HTML codes.
-   - `<treatySubject>` (e.g., International Law and Organization)
-      - The assigned topic of the treaty.  
-   - `<updateDate>` (e.g., 2022-08-04T02:46:11Z)
-      - The date of update on Congress.gov.
-   - `<parts>`
-        - Container for treaty part information. A `<parts>` element may include the following children (the below data is taken from https://api.congress.gov/v3/treaty/114/13):
-           - `<count>` (e.g., 2)
-               - The number of treaty parts.
-		  - `<urls>`
-		      - Container for the referrer URLs to the treaty part items in the API. A `<urls>` element may include the following children:
-	              - `<item>` (e.g., https://api.congress.gov/v3/treaty/114/13/B)
-		            - A referrer URL to the treaty part item in the API.
-   - `<actions>`
-      - Container for actions on the treaty. An `<actions>` element may include the following children:
-		  - `<count>` (e.g., 7)
-		       - The number of actions on the treaty.
-		  - `<url>` (e.g., https://api.congress.gov/congress/v3/treaty/117/3/actions)
-		       - A referrer URL to the actions level of the treaty API. Click [here](#actions-level) for more information about the actions level.
-			
+    - The number assigned to treaties ratified prior to the 97th Congress.
+    - To allow for searching by treaty document number on Congess.gov, old treaty numbers were converted. View the table that converts the old numbering to a new one at the [Treaty Numbers Conversion Table](https://www.congress.gov/help/treaty-documents#conversion) on Congress.gov.
+  - `<oldTreatyNumDisplayStr>`
+    - The original treaty number display string, prior to conversion, for treaties ratified prior to the 97th Congress.
+    - To allow for searching by treaty document number on Congess.gov, old treaty numbers were converted. View the table that converts the old numbering method to a new one at the [Treaty Numbers Conversion Table](https://www.congress.gov/help/treaty-documents#conversion) on Congress.gov.
+  - `<transmittedDate>` (e.g., 2022-07-11T00:00:00Z)
+    - The date the treaty was transmitted to the Senate.
+  - `<inForceDate>`
+    - The date when the treaty agreement takes effect.
+  - `<relatedDocs>`
+    - Container for executive reports associated with the treaty. A `<relatedDocs>` element may include the following children (the data below is taken from <https://api.congress.gov/v3/treaty/116/1>):
+      - `<item>`
+        - Container element for individual executive reports associated with the treaty. An `<item>` element may include the following children:
+          - `<name>` (e.g., Ex. Rept. 116-5)
+            - The citation for the associated executive report.
+          - `<url>` (e.g., <https://api.congress.gov/v3/committee-report/116/ERPT/5>)
+            - A referrer URL to the executive report item in the API. Documentation on committee reports is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeReportEndpoint.md).
+  - `<resolutionText>` (e.g., `<![CDATA[<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head><meta name="meta:creation-date" content="2022/08/03 18:28:08" /><meta name="dc:title" content="[117] TreatyRes. 6 for TreatyDoc. 117 - 3" /><meta name="Creation-Date" content="2022/08/03 18:28:08" /><meta name="dcterms:created" content="2022/08/03 18:28:08" /><meta name="Content-Type" content="application/rtf" /><title>[117] TreatyRes. 6 for TreatyDoc. 117 - 3</title></head><body><p>As approved by the Senate: </p><p><i>Resolved (two-thirds of the Senators present concurring therein),</i></p><p></p><p><b>SECTION 1. SENATE ADVICE AND CONSENT SUBJECT TO DECLARATIONS AND CONDITIONS.</b></p><p></p><p>The Senate advises and consents to the ratification of the Protocols to the North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden, which were signed on July 5, 2022, by the United States of America and other parties to the North Atlantic Treaty of 1949 (Treaty Doc. 117-3), subject to the declarations of section 2 and the condition of section 3.</p><p><b>SEC. 2. DECLARATIONS.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following declarations:</p><p>(1)Reaffirmation That United States Membership in NATO Remains a Vital National Security Interest of the United States.- The Senate declares that-</p><p>(A)for more than 70 years the North Atlantic Treaty Organization (NATO) has served as the preeminent organization to defend the countries in the North Atlantic area against all external threats;</p><p>(B)through common action, the established democracies of North America and Europe that were joined in NATO persevered and prevailed in the task of ensuring the survival of democratic government in Europe and North America throughout the Cold War;</p><p>(C)NATO enhances the security of the United States by embedding European states in a process of cooperative security planning and by ensuring an ongoing and direct leadership role for the United States in European security affairs;</p><p>(D)the responsibility and financial burden of defending the democracies of Europe and North America can be more equitably shared through an alliance in which specific obligations and force goals are met by its members;</p><p>(E)the security and prosperity of the United States is enhanced by NATO's collective defense against aggression that may threaten the security of NATO members; and</p><p>(F)United States membership in NATO remains a vital national security interest of the United States.</p><p>(2)Strategic Rationale for NATO Enlargement.- The Senate declares that-</p><p>(A)the United States and its NATO allies face continued threats to their stability and territorial integrity;</p><p>(B)an attack against Finland or Sweden, or the destabilization of either arising from external subversion, would threaten the stability of Europe and jeopardize United States national security interests;</p><p>(C)Finland and Sweden, having established democratic governments and having demonstrated a willingness to meet the requirements of membership, including those necessary to contribute to the defense of all NATO members, are in a position to further the principles of the North Atlantic Treaty and to contribute to the security of the North Atlantic area; and</p><p>(D)extending NATO membership to Finland and Sweden will strengthen NATO, enhance stability in Europe, and advance the interests of the United States and its NATO allies.</p><p>(3)Support for NATO's Open Door Policy.- The policy of the United States is to support NATO's Open Door Policy that allows any European country to express its desire to join NATO and demonstrate its ability to meet the obligations of NATO membership.</p><p>(4)Future Consideration of Candidates for Membership in NATO.-</p><p>(A)Senate Finding.-The Senate finds that the United States will not support the accession to the North Atlantic Treaty of, or the invitation to begin accession talks with, any European state (other than Finland and Sweden), unless-</p><p>(i)the President consults with the Senate consistent with Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties); and</p><p>(ii)the prospective NATO member can fulfill all of the obligations and responsibilities of membership, and the inclusion of such state in NATO would serve the overall political and strategic interests of NATO and the United States.</p><p>(B)Requirement for Consensus and Ratification.-The Senate declares that no action or agreement other than a consensus decision by the full membership of NATO, approved by the national procedures of each NATO member, including, in the case of the United States, the requirements of Article II, section 2, clause 2 of the Constitution of the United States (relating to the advice and consent of the Senate to the making of treaties), will constitute a commitment to collective defense and consultations pursuant to Articles 4 and 5 of the North Atlantic Treaty.</p><p>(5)Influence of Non-NATO Members on NATO Decisions.- The Senate declares that any country that is not a member of NATO shall have no impact on decisions related to NATO enlargement.</p><p>(6)Support for 2014 Wales Summit Defense Spending Benchmark.--The Senate declares that all NATO members should spend a minimum of 2 percent of their Gross Domestic Product (GDP) on defense and 20 percent of their defense budgets on major equipment, including research and development, by 2024, as outlined in the 2014 Wales Summit Declaration.</p><p><b>SEC. 3. CONDITION.</b></p><p></p><p>The advice and consent of the Senate under section 1 is subject to the following conditions</p><p>(1)Presidential Certification.-Prior to the deposit of the instrument of ratification, the President shall certify to the Senate as follows:</p><p>(A)The inclusion of Finland and Sweden in NATO will not have the effect of increasing the overall percentage share of the United States in the common budgets of NATO.</p><p>(B)The inclusion of Finland and Sweden in NATO does not detract from the ability of the United States to meet or to fund its military requirements outside the North Atlantic area.</p><p><b>SEC. 4. DEFINITIONS.</b></p><p></p><p>In this resolution:</p><p>(1)NATO Members.-The term &ldquo;NATO members&rdquo; means all countries that are parties to the North Atlantic Treaty.</p><p>(2)Non-NATO Members.-The term &ldquo;non-NATO members&rdquo; means all countries that are not parties to the North Atlantic Treaty.</p><p>(3)North Atlantic Area.-The term &ldquo;North Atlantic Area&rdquo; means the area covered by Article 6 of the North Atlantic Treaty, as applied by the North Atlantic Council.</p><p>(4)North Atlantic Treaty.-The term &ldquo;North Atlantic Treaty&rdquo; means the North Atlantic Treaty, signed at Washington April 4, 1949 (63 Stat. 2241; TIAS 1964), as amended.</p><p>(5)United States Instrument of Ratification.-The term &ldquo;United States instrument of ratification&rdquo; means the instrument of ratification of the United States of the Protocols to the</p><p>North Atlantic Treaty of 1949 on the Accession of the Republic of Finland and the Kingdom of Sweden.</p></body></html>]]>`)
+    - The text of the resolution of ratification.
+    - Note that the text is encased in CDATA and includes HTML codes.
+  - `<treatySubject>` (e.g., International Law and Organization)
+    - The assigned topic of the treaty.  
+  - `<updateDate>` (e.g., 2022-08-04T02:46:11Z)
+    - The date of update on Congress.gov.
+  - `<parts>`
+    - Container for treaty part information. A `<parts>` element may include the following children (the below data is taken from <https://api.congress.gov/v3/treaty/114/13>):
+      - `<count>` (e.g., 2)
+        - The number of treaty parts.
+      - `<urls>`
+        - Container for the referrer URLs to the treaty part items in the API. A `<urls>` element may include the following children:
+      - `<item>` (e.g., <https://api.congress.gov/v3/treaty/114/13/B>)
+        - A referrer URL to the treaty part item in the API.
+  - `<actions>`
+    - Container for actions on the treaty. An `<actions>` element may include the following children:
+      - `<count>` (e.g., 7)
+        - The number of actions on the treaty.
+      - `<url>` (e.g., <https://api.congress.gov/congress/v3/treaty/117/3/actions>)
+        - A referrer URL to the actions level of the treaty API. Click [here](#actions-level) for more information about the actions level.
+
 ### Actions Level
 
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
-`<actions>` (the example below is based on https://api.congress.gov/v3/treaty/114/13/A/actions. While this example is a treaty with parts, the same structure exists for treaties without parts.)
+`<actions>` (the example below is based on <https://api.congress.gov/v3/treaty/114/13/A/actions>. While this example is a treaty with parts, the same structure exists for treaties without parts.)
+
 - Parent container for actions on a treaty. An `<actions>` element may include the following children:
-   - `<item>` 
-      - Container for an individual action on a treaty. An `<item>` element is repeatable and may include the following children:
-         - `<type>` (e.g., IntroReferral)
-              - A short name representing stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent Senate processes.
-              - Possible values include "Calendars", "Committee", "Discharge", "Floor", and "IntroReferral".
-        - `<committee>`
-           - Container for committee information. A `<committee>` element may include the following children:
-              - `<systemCode>` (e.g., ssfr00)
-                  - Unique ID value for the committee.
-              - `<name>` (e.g., Foreign Relations Committee)
-                  - The name of the committee.
-              - `<url>` (e.g., https://api.congress.gov/v3/committee/senate/ssfr00)
-                  - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
-        - `<actionCode>` (e.g, S05120)
-             - A Senate-provided action code associated with the action taken on a treaty. 
-        - `<actionDate>` (e.g., 2016-12-09)
-             - The date of action taken on the treaty. 
-        - `<text>` (e.g., Received in the Senate and referred to the Committee on Foreign Relations by unanimous consent removing the injunction of secrecy.)
-            - The text of the action taken on the treaty.
+  - `<item>`
+    - Container for an individual action on a treaty. An `<item>` element is repeatable and may include the following children:
+      - `<type>` (e.g., IntroReferral)
+        - A short name representing stages or categories of more detailed actions. Most types condense actions into sets. Some types are used for data processing and do not represent Senate processes.
+        - Possible values include "Calendars", "Committee", "Discharge", "Floor", and "IntroReferral".
+      - `<committee>`
+        - Container for committee information. A `<committee>` element may include the following children:
+          - `<systemCode>` (e.g., ssfr00)
+            - Unique ID value for the committee.
+          - `<name>` (e.g., Foreign Relations Committee)
+            - The name of the committee.
+          - `<url>` (e.g., <https://api.congress.gov/v3/committee/senate/ssfr00>)
+            - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
+      - `<actionCode>` (e.g, S05120)
+        - A Senate-provided action code associated with the action taken on a treaty.
+      - `<actionDate>` (e.g., 2016-12-09)
+        - The date of action taken on the treaty.
+      - `<text>` (e.g., Received in the Senate and referred to the Committee on Foreign Relations by unanimous consent removing the injunction of secrecy.)
+        - The text of the action taken on the treaty.
 
 ### Committees Level  
+
 `<api-root>`
 
 The `<api-root>` is only present in the XML format.
 
-`<treatyCommittees>` (the example below is based on https://api.congress.gov/v3/treaty/116/3/committees.)
-  - Parent container for committees with activity associated with the treaty. A `<treatyCommittees>` element may include the following children: 
-     - `<item>` 
-        - Container for the individual elements associated with a committee taking action on a treaty. An `<item>` element is repeatable and may include the following children: 
-           - `<url>` (e.g., https://api.congress.gov/v3/committee/senate/ssfr00)
-	          - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md). 
-           - `<systemCode>` (e.g, ssfr00)
-	          - Unique ID value for the committee. 
-           - `<name>` (e.g, Foreign Relations Committee)
-	          - The name of the committee or subcommittee.
-           - `<chamber>` (e.g., Senate)
-	          - The chamber where the committee operates. This value will always be set to "Senate".
-           - `<type>` (e.g., Standing)
-	          - The type or status of the committee. This value will always be set to "Standing".
-           - `<subcommittees>` 
-	          - Container for subcommittees with activity associated with the nomination.
-           - `<activities>`
-	          - Container for the committee or subcommittee activities associated with the treaty. An `<activities>` element may include the following children:
-	              - `<item>`
-	                  - Container for a committee or subcommittee activity. An `<item>` element is repeatable and may include the following children:
-	                     - `<name>` (e.g., Referred to)
-	                         - The committee or subcommittee activity.
-	                         - Possible values are "Referred to", "Re-Referred to", "Reported by", and "Discharged from".
-	                     - `<date>` (e.g., 2020-06-18T20:19:22Z)
-	                         - The date of the committee or subcommittee activity.
+`<treatyCommittees>` (the example below is based on <https://api.congress.gov/v3/treaty/116/3/committees>.)
+
+- Parent container for committees with activity associated with the treaty. A `<treatyCommittees>` element may include the following children:
+  - `<item>`
+    - Container for the individual elements associated with a committee taking action on a treaty. An `<item>` element is repeatable and may include the following children:
+      - `<url>` (e.g., <https://api.congress.gov/v3/committee/senate/ssfr00>)
+        - A referrer URL to the committee item in the API. Documentation for the committee endpoint is available [here](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/Documentation/CommitteeEndpoint.md).
+      - `<systemCode>` (e.g, ssfr00)
+        - Unique ID value for the committee.
+      - `<name>` (e.g, Foreign Relations Committee)
+        - The name of the committee or subcommittee.
+      - `<chamber>` (e.g., Senate)
+        - The chamber where the committee operates. This value will always be set to "Senate".
+      - `<type>` (e.g., Standing)
+        - The type or status of the committee. This value will always be set to "Standing".
+      - `<subcommittees>`
+        - Container for subcommittees with activity associated with the nomination.
+      - `<activities>`
+        - Container for the committee or subcommittee activities associated with the treaty. An `<activities>` element may include the following children:
+          - `<item>`
+            - Container for a committee or subcommittee activity. An `<item>` element is repeatable and may include the following children:
+              - `<name>` (e.g., Referred to)
+                - The committee or subcommittee activity.
+                - Possible values are "Referred to", "Re-Referred to", "Reported by", and "Discharged from".
+              - `<date>` (e.g., 2020-06-18T20:19:22Z)
+                - The date of the committee or subcommittee activity.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
 # Overview
+
 ## Introduction
+
 The beta [Congress.gov Application Programming Interface (API)](https://api.congress.gov/)  provides a method for Congress and the public to view, retrieve, and re-use machine-readable data from collections available on Congress.gov. This repository contains information on accessing and using the beta Congress.gov API, as well as documentation on available endpoints.
 
-Within the beta Congress.gov API, responses are returned in XML or JSON formats. An `<api-root>` element will be visible for responses returned in XML. 
+Within the beta Congress.gov API, responses are returned in XML or JSON formats. An `<api-root>` element will be visible for responses returned in XML.
 
 For every request, three elements are returned:
+
 - The **Request** element contains information about the API request itself. This includes the format and the `<contentType>`; this is essentially the information you might expect to see in a request header.
 - The **Pagination** element contains a count of how many total data items are contained within the response, a URL containing the next page of results; and, if the offset is greater than 1, a URL containing the previous page of results.
-- The **Data** element, the name of which changes depending on the endpoint utilized (i.e. `<bills>` for the bill endpoint, `<amendments>` for the amendment endpoint, etc.). This element contains a list of all data items returned by your API call. 
+- The **Data** element, the name of which changes depending on the endpoint utilized (i.e. `<bills>` for the bill endpoint, `<amendments>` for the amendment endpoint, etc.). This element contains a list of all data items returned by your API call.
+
 ## Key/Authentication
+
 An API key is required for access. Sign up for a key [here](https://api.congress.gov/sign-up/).
+
 ## Versioning
+
 The current version of the API is version 3 (v3). Prior versions were used by the Government Publishing Office (GPO) for its [Bulk Data Repository](https://www.govinfo.gov/bulkdata), and other clients.
+
 ## Rate Limit
+
 The rate limit is set to 1,000 requests per hour.
+
 ## Limit and Offset
-By default, the API returns 20 results starting with the first record. The 20 results limit can be adjusted up to 250 results. If the limit is adjusted to be greater than 250 results, only 250 results will be returned. The offset, or the starting record, can also be adjusted to be greater than 0. 
+
+By default, the API returns 20 results starting with the first record. The 20 results limit can be adjusted up to 250 results. If the limit is adjusted to be greater than 250 results, only 250 results will be returned. The offset, or the starting record, can also be adjusted to be greater than 0.
+
 ## Support
-Congress.gov staff will monitor and respond to any [issues](https://github.com/LibraryOfCongress/api.congress.gov/issues) created in this repository, and will initiate actions, as necessary. Before creating an issue in the repository, please review existing issues and add a comment to any issues relevant to yours. 
+
+Congress.gov staff will monitor and respond to any [issues](https://github.com/LibraryOfCongress/api.congress.gov/issues) created in this repository, and will initiate actions, as necessary. Before creating an issue in the repository, please review existing issues and add a comment to any issues relevant to yours.
+
 ## Change Management
+
 Congress.gov staff will issue change management communication through the [ChangeLog](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/ChangeLog.md) so that consumers are able to adjust accordingly. The [ChangeLog](https://github.com/LibraryOfCongress/api.congress.gov/blob/main/ChangeLog.md) will contain information on updates to the API, the impacted endpoints, and the expected production release date. Milestones are also used to tag issues with expected production release date information.

--- a/api_client/README.md
+++ b/api_client/README.md
@@ -1,10 +1,8 @@
 # Congress Dot Gov - Example API Client
 
-
 Example code for a CDG API Client is located here.
 
-
-### Important note about the API Authorization Key
+## Important note about the API Authorization Key
 
 The API key assigned to your organization is not meant to be shared.  It should:
 
@@ -29,15 +27,11 @@ to your application.  In absence of such system, other reasonable choices are:
 - For manually run programs, use the "keyring" functionality of your
   Operating System to store the secret (see Python example).
 
-
 ### Example Code
 
 There are examples in more than one programming language,
 see the subfolders in this repository.
 Kindly click on the folders to view.
-
-
-<p>&nbsp;</p>
 
 ---
 © 2022, Library of Congress via Congress.gov

--- a/api_client/python/README.md
+++ b/api_client/python/README.md
@@ -1,6 +1,5 @@
 # CDG Example Client with Python
 
-
 ## Table of contents
 
 - [Requirements](#requirements)
@@ -13,8 +12,9 @@
 - [Additional Information](#additional-information)
 
 ## Requirements
+
 This client with developed and tested with Python 3.8 so should work with that version
-and above. We have tested with older Python versions. 
+and above. We have tested with older Python versions.
 
 This example client requires the `requests` package, and optionally the `keyring`
 package.
@@ -32,7 +32,7 @@ JSON is the default data serialization format.
 On Unix, you may want to directly run the example scripts as executable files,
 though they work after the `python` command as well:
 
-```
+```bash
 ⏵ chmod a+x cdg_cli bill_example.py
 ```
 
@@ -40,9 +40,8 @@ Windows folks will probably need to type `python` before any scripts,
 assuming python is on your PATH.
 
 ## API Credentials
-Sign up for and retrieve your API key from https://api.congress.gov/sign-up
 
-
+Sign up for and retrieve your API key from <https://api.congress.gov/sign-up>
 
 ## Typical Use of CDGClient
 
@@ -65,7 +64,6 @@ data, status_code = client.get(endpoint, *args, **kwargs)
 
 Below are a few fleshed out examples.
 
-
 ### Command line interface ➧ `cdg_cli`
 
 `cdg_cli` is an example of:
@@ -87,50 +85,71 @@ API Key:               # Do paste it here ✓
   INFO     API Key was saved.
 
 # Now you can run it
-now you want to look at bill/hr/21/committeess, write:
+```
 
+Now, to look at bill/hr/21/committeess, write:
+
+```sh
 ⏵ python cdg_cli bill/117/hr/21/committees
   INFO     __main__/main:111 HTTP Status: 200
   INFO     __main__/main:112 API Returned:
-{'committees': [{'activities': [{'date': '2021-01-07T01:26:34Z',
-                                 'name': 'Referred to'}],
-                 'chamber': 'Senate',
-                 'name': 'Homeland Security and Governmental Affairs Committee',
-                 'subcommittees': [],
-                 'systemCode': 'ssga00',
-                 'type': 'Standing',
-                 'url': 'https://api.congress.gov/v3/committee/senate/ssga00?format=json'},
-                {'activities': [{'date': '2021-01-04T15:11:25Z',
-                                 'name': 'Referred to'}],
-                 'chamber': 'House',
-                 'name': 'Oversight and Reform Committee',
-                 'subcommittees': [],
-                 'systemCode': 'hsgo00',
-                 'type': 'Standing',
-                 'url': 'https://api.congress.gov/v3/committee/house/hsgo00?format=json'}],
- 'request': {'billNumber': '21',
-             'billType': 'hr',
-             'billUrl': 'https://api.congress.gov/v3/bill/117/hr/21?format=json',
-             'congress': '117',
-             'contentType': 'application/json',
-             'format': 'json'}}
 ```
 
-<p>&nbsp;</p>
+```json
+{
+    "committees": [
+        {
+            "activities": [
+                {
+                    "date": "2021-01-07T01: 26: 34Z",
+                    "name": "Referred to"
+                }
+            ],
+            "chamber": "Senate",
+            "name": "Homeland Security and Governmental Affairs Committee",
+            "subcommittees": [],
+            "systemCode": "ssga00",
+            "type": "Standing",
+            "url": "https: //api.congress.gov/v3/committee/senate/ssga00?format=json"
+        },
+        {
+            "activities": [
+                {
+                    "date": "2021-01-04T15:11:25Z",
+                    "name": "Referred to"
+                }
+            ],
+            "chamber": "House",
+            "name": "Oversight and Reform Committee",
+            "subcommittees": [],
+            "systemCode": "hsgo00",
+            "type": "Standing",
+            "url": "https://api.congress.gov/v3/committee/house/hsgo00?format=json"
+        }
+    ],
+    "request": {
+        "billNumber": "21",
+        "billType": "hr",
+        "billUrl": "https://api.congress.gov/v3/bill/117/hr/21?format=json",
+        "congress": "117",
+        "contentType": "application/json",
+        "format": "json"
+    }
+}
+```
 
 ## Configurable options
 
 | Key                      | Description                                                        | Values                                       |
 |--------------------------|--------------------------------------------------------------------|----------------------------------------------|
-| *API_KEY*                | The API key used to authenticate calls                             | Retrieved from https://api.congress.gov      |
+| *API_KEY*                | The API key used to authenticate calls                             | Retrieved from <https://api.congress.gov>      |
 | *RESPONSE_FORMAT*        | Sets the response format returned by the API                       | xml, json                                    |
 | *BILL.CONGRESS*          | The numerical value of the congress to query                       | 1 - 117 (or current congress)                |
 | *BILL.CHAMBER*           | The congressional chamber                                          | hr, s, sjres, hjres                          |
-| *BILL.NUMBER*            | The bill number to query                                           | A valid bill number from https://congress.gov |
+| *BILL.NUMBER*            | The bill number to query                                           | A valid bill number from <https://congress.gov> |
 | *BILL.URL*               | The bill url for the API to query                                  | bill                                         |
 
-
-### How to talk to various endpoints:
+### How to talk to various endpoints
 
 `bill_example` is an example of:
 
@@ -139,8 +158,7 @@ now you want to look at bill/hr/21/committeess, write:
 - Using an external "secrets" config file.
 - Using the XML format.
 
-
-```
+```sh
 ⏵  python3 bill_example.py
  1. bill:
    - congress:            '117'
@@ -155,9 +173,8 @@ now you want to look at bill/hr/21/committeess, write:
  ...
 ```
 
-<p>&nbsp;</p>
-
 ## Client arguments
+
 Other options allowed as arguments to python bill_example.py are:
 
 | Argument             | Description                              |
@@ -179,7 +196,9 @@ Other options allowed as arguments to python bill_example.py are:
 |  *bill_titles*       | Gets a bills titles                      |
 
 ## Additional Information
-- For more information and the full API reference, please visit https://api.congress.gov/
-- Alternative ways to make use of your API key when making calls can be found here: https://api.data.gov/docs/api-key/
+
+- For more information and the full API reference, please visit <https://api.congress.gov/>
+- Alternative ways to make use of your API key when making calls can be found here: <https://api.data.gov/docs/api-key/>
+
 ---
 © 2022, Library of Congress via Congress.gov


### PR DESCRIPTION
Starting to use api.congress.gov and my markdown linter was angry about a number of formatting things, so I fixed those.  Mostly had to do with lists, numbered and otherwise, using a mix of tabs and whitespace.