### PR TITLE
chore(issue templates): bug-report, config, documentation, feature-request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,40 @@
+---
+name: "🐛 Bug Report"
+description: Report a bug
+title: "(API name): (short issue description)"
+labels: [bug]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What is the problem? A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: |
+        What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: |
+        What actually happened?
+
+        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+    validations:
+      required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: |
+        Anything else that might be relevant for troubleshooting this bug.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+---
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,14 @@
+---
+name: "📕 Documentation Issue"
+description: Report an issue in the documentation
+title: "(API name): (short issue description)"
+labels: [documentation]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of the issue.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,7 @@
 name: 🚀 Feature Request
 description: Suggest an idea for this project
 title: "(API name): (short issue description)"
-labels: [feature-request]
+labels: [enhancement]
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,30 @@
+---
+name: 🚀 Feature Request
+description: Suggest an idea for this project
+title: "(API name): (short issue description)"
+labels: [feature-request]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of the feature you are proposing.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Why do you need this feature? For example: "I'm always frustrated when..."
+    validations:
+        required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: |
+        Any alternative solutions or features you considered, a more detailed explanation, stack traces, related issues, links for context, etc.
+    validations:
+      required: false


### PR DESCRIPTION
Provided some basic issue templates to help submitters provide consistent and relevant info. This will also help organize issues by auto-labeling by issue type.

e.g. When a user submits a "Bug Report" it will automatically be labelled with `bug` (defined [here](https://github.com/ryparker/api.congress.gov/blob/bf3125d965469bd08ed22f9186a2457c087bdd10/.github/ISSUE_TEMPLATE/bug-report.yml?plain=1#L5))

GitHub issue template documentation: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository