### PR TITLE
docs(DailyCongressionalRecordEndpoint.md): revert removal of `<part>`

### DIFF
--- a/Documentation/DailyCongressionalRecordEndpoint.md
+++ b/Documentation/DailyCongressionalRecordEndpoint.md
@@ -96,6 +96,8 @@ Parent container for congressional record issues. A `<dailyCongressionalRecord>`
                 - Container for section text items. A `<text>` element may include the following children:
                 - `<item>`
                   - Container for a section text item. An `<item>` element may include the following children:
+                  - `<part>`
+                     - The part of the daily Congressional Record issue.
                   - `<type>`
                      - The type of document that the daily Congressional Record is (e.g. PDF, "Formatted Text").
                   - `<url>`
@@ -135,11 +137,8 @@ Parent container for congressional record issues. A `<dailyCongressionalRecord>`
               - The container for article text items.  A `<text>` element may include the following children:
                 - `<item>`
                    - Container for an article text item. An `<item>` element may include the following children:
-                     - `<part>`
-                     - The part of the daily Congressional Record issue.
-                     - `<type>`
-                     - The type of document that the daily Congressional Record article is (e.g. PDF, "Formatted Text").
-                     - `<url>`
-                     - The article URL.
-                        
+                   - `<type>`
+                      - The type of document that the daily Congressional Record article is (e.g. PDF, "Formatted Text").
+                   - `<url>`
+                      - The article URL.
      


### PR DESCRIPTION
Follow up from https://github.com/LibraryOfCongress/api.congress.gov/pull/221#issuecomment-2023955966